### PR TITLE
feat: wire up GTM (GTM-K46LNVH2) and GA4 (G-FHVLZGB0CY)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -240,7 +240,7 @@ These variables are embedded during the build process:
 | Variable                         | Purpose                    | Default           | Required |
 | -------------------------------- | -------------------------- | ----------------- | -------- |
 | `NEXT_PUBLIC_BASE_PATH`          | Base path for GitHub Pages | (empty)           | No       |
-| `NEXT_PUBLIC_GA_MEASUREMENT_ID`  | Google Analytics ID        | `G-XXXXXXXXXX`    | No       |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID`  | Google Analytics ID        | `G-FHVLZGB0CY`    | No       |
 | `NEXT_PUBLIC_META_PIXEL_ID`      | Meta Pixel ID              | `XXXXXXXXXXXXXXX` | No       |
 | `NEXT_PUBLIC_CLARITY_PROJECT_ID` | Microsoft Clarity ID       | `XXXXXXXXXX`      | No       |
 

--- a/EXTERNAL_DEPENDENCIES.md
+++ b/EXTERNAL_DEPENDENCIES.md
@@ -27,7 +27,7 @@ These are services we directly integrate into our application code.
 #### 1. Google Tag Manager (GTM)
 
 - **Purpose:** Tag management system for analytics and marketing pixels
-- **GTM ID:** `GTM-TQ5H8HPR`
+- **GTM ID:** `GTM-K46LNVH2`
 - **Implementation:** `src/components/google-tag-manager/index.tsx`
 - **Load Strategy:** `lazyOnload` for better performance
 - **Data Collected:** Page views, user interactions, custom events

--- a/HUBSPOT_INVESTIGATION.md
+++ b/HUBSPOT_INVESTIGATION.md
@@ -79,7 +79,7 @@ The application **does** intentionally integrate with the following third-party 
 
 **Location:** `src/components/cookie-consent/index.tsx`
 
-- **Google Analytics** (`G-XXXXXXXXXX`) - Loaded if analytics consent given
+- **Google Analytics** (`G-FHVLZGB0CY`) - Loaded if analytics consent given
 - **Meta Pixel** (Facebook) - Loaded if marketing consent given
 - **Microsoft Clarity** - Loaded if analytics consent given
 

--- a/HUBSPOT_INVESTIGATION.md
+++ b/HUBSPOT_INVESTIGATION.md
@@ -107,7 +107,7 @@ The application **does** intentionally integrate with the following third-party 
 
 **Location:** `src/components/google-tag-manager/index.tsx`
 
-**GTM ID:** `GTM-TQ5H8HPR`  
+**GTM ID:** `GTM-K46LNVH2`  
 **Load Strategy:** `lazyOnload` for better performance
 
 ---

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
 
-// Environment variables for tracking IDs (replace with actual values)
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
+// Tracking IDs. These are public identifiers (safe to commit), with optional
+// environment-variable overrides. GA4 property for freedomrisingusa.org.
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-FHVLZGB0CY'
 const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || 'XXXXXXXXXXXXXXX'
 const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || 'XXXXXXXXXX'
 

--- a/src/components/google-tag-manager/index.tsx
+++ b/src/components/google-tag-manager/index.tsx
@@ -3,7 +3,7 @@
 import Script from 'next/script'
 
 // Google Tag Manager ID
-const GTM_ID = 'GTM-TQ5H8HPR'
+const GTM_ID = 'GTM-K46LNVH2'
 
 export default function GoogleTagManager() {
   return (

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -118,7 +118,7 @@ test.describe('Google Tag Manager Integration', () => {
 
 test.describe('Google Tag Manager Configuration', () => {
   test('should load GTM script with hardcoded ID', async ({ page }) => {
-    // This test verifies that GTM loads with the hardcoded ID GTM-TQ5H8HPR
+    // This test verifies that GTM loads with the hardcoded ID GTM-K46LNVH2
     // The GTM_ID is hardcoded in the component (not from environment variable)
 
     await page.goto('/')
@@ -131,6 +131,6 @@ test.describe('Google Tag Manager Configuration', () => {
 
     // Verify the script contains the correct GTM ID
     const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
-    expect(scriptContent).toContain('GTM-TQ5H8HPR')
+    expect(scriptContent).toContain('GTM-K46LNVH2')
   })
 })


### PR DESCRIPTION
## Summary
- Update the Google Tag Manager container ID to the production container `GTM-K46LNVH2` (component, E2E test, and docs).
- Set the GA4 measurement ID to `G-FHVLZGB0CY` as the hardcoded default for the consent-gated analytics loader (env var override still supported), and update docs to reference it.

## Details
- **GTM** was already wired into the layout per Google's snippet (script in `<head>`, noscript after `<body>`); only the container ID needed updating — `src/components/google-tag-manager/index.tsx`.
- **GA4** loads via gtag.js (matching the pasted snippet) but only after a visitor grants analytics consent, with `anonymize_ip` enabled — `src/components/cookie-consent/index.tsx`.
- GA fires directly (not as a tag inside GTM), so a GA4 Configuration tag for `G-FHVLZGB0CY` should **not** also be added inside the GTM dashboard, to avoid double-counting pageviews.
- These IDs are public identifiers, intentionally committed in plain code/docs (not secrets) so they're easy for the charity to find.

## Test plan
- [x] `npm run lint` — clean (only pre-existing `<img>` warnings)
- [x] `npm test` — 25 unit tests pass
- [x] `npm run build` — static export succeeds
- [x] `npm run test:e2e` — 14 cookie-consent tests pass; GTM tests pass in isolation (2 flake under parallel load due to lazy-loaded script timing, pre-existing)

https://claude.ai/code/session_01CxBGCCV6UisEj2nXoP9y2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxBGCCV6UisEj2nXoP9y2m)_