### PR TITLE
feat: Consent Mode v2 + Organization/Event structured data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from './../components/header'
 import Footer from './../components/footer'
 import CookieConsent from './../components/cookie-consent'
 import GoogleTagManager, { GoogleTagManagerNoScript } from './../components/google-tag-manager'
+import { OrganizationJsonLd } from './../components/structured-data'
 import {
   openSans,
   lato,
@@ -110,12 +111,28 @@ export default function RootLayout({
           fetchPriority="high"
         />
 
-        {/* Ensure GTM-compatible dataLayer exists as early as possible */}
+        {/* Google Consent Mode v2 defaults — must run before GTM/GA load */}
         <script
-          dangerouslySetInnerHTML={{ __html: 'window.dataLayer = window.dataLayer || [];' }}
+          id="consent-mode-default"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('consent', 'default', {
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                analytics_storage: 'denied',
+                functionality_storage: 'granted',
+                security_storage: 'granted',
+                wait_for_update: 500
+              });
+            `,
+          }}
         />
 
         <GoogleTagManager />
+        <OrganizationJsonLd />
       </head>
       <body
         className={[

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 // import HomePage from './Home/page'
 import HomePage from '@/app/home-page'
+import { ParadeEventJsonLd } from '@/components/structured-data'
 
 const page = () => {
   return (
     <div>
-      {/* <HomePage /> */}
+      <ParadeEventJsonLd />
       <HomePage />
     </div>
   )

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -19,6 +19,7 @@ interface DataLayerEvent {
 declare global {
   interface Window {
     dataLayer: DataLayerEvent[]
+    gtag?: (...args: unknown[]) => void
     openCookiePreferences?: () => void
   }
 }
@@ -156,9 +157,19 @@ export default function CookieConsent() {
         }
       }
 
-      // Push consent update to GTM dataLayer
+      // Update Google Consent Mode v2 signals, then push the custom event
       if (typeof window !== 'undefined') {
         window.dataLayer = window.dataLayer || []
+
+        if (typeof window.gtag === 'function') {
+          window.gtag('consent', 'update', {
+            analytics_storage: prefs.analytics ? 'granted' : 'denied',
+            ad_storage: prefs.marketing ? 'granted' : 'denied',
+            ad_user_data: prefs.marketing ? 'granted' : 'denied',
+            ad_personalization: prefs.marketing ? 'granted' : 'denied',
+          })
+        }
+
         window.dataLayer.push({
           event: 'consent_update',
           functional_consent: prefs.functional ? 'granted' : 'denied',

--- a/src/components/structured-data/index.tsx
+++ b/src/components/structured-data/index.tsx
@@ -1,0 +1,73 @@
+const SITE_URL = 'https://freedomrisingusa.org'
+
+function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  )
+}
+
+export function OrganizationJsonLd() {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@type': 'NGO',
+        name: 'Freedom Rising USA',
+        url: SITE_URL,
+        logo: `${SITE_URL}/web-app-manifest-512x512.png`,
+        description:
+          'Freedom Rising USA is a 501(c)(3) nonprofit organization dedicated to honoring heritage and celebrating service in Centre County, PA.',
+        email: 'contact@freedomrisingusa.org',
+        telephone: '+1-571-257-6411',
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: 'State College',
+          addressRegion: 'PA',
+          postalCode: '16803',
+          addressCountry: 'US',
+        },
+        sameAs: [
+          'https://www.facebook.com/freedomrisingusa',
+          'https://x.com/USFreedomRising',
+          'https://www.linkedin.com/company/freedomrisingusa/',
+        ],
+      }}
+    />
+  )
+}
+
+export function ParadeEventJsonLd() {
+  return (
+    <JsonLd
+      data={{
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: '2026 Central Pennsylvania Independence Day Parade',
+        description:
+          'Annual Independence Day parade in downtown State College, PA, organized by Freedom Rising USA to honor veterans and celebrate American heritage.',
+        startDate: '2026-07-04T11:00:00-04:00',
+        endDate: '2026-07-04T13:00:00-04:00',
+        eventStatus: 'https://schema.org/EventScheduled',
+        eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+        url: `${SITE_URL}/parade-brief`,
+        location: {
+          '@type': 'Place',
+          name: 'Downtown State College',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'State College',
+            addressRegion: 'PA',
+            postalCode: '16803',
+            addressCountry: 'US',
+          },
+        },
+        organizer: {
+          '@type': 'NGO',
+          name: 'Freedom Rising USA',
+          url: SITE_URL,
+        },
+        isAccessibleForFree: true,
+      }}
+    />
+  )
+}

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -25,7 +25,9 @@ test.describe('Google Tag Manager Integration', () => {
   test('should load GTM script with correct ID', async ({ page }) => {
     await page.goto('/')
 
-    // Check for GTM script element
+    // GTM uses lazyOnload — wait for the script element to be injected
+    await page.waitForSelector('script#gtm-script', { state: 'attached', timeout: 15000 })
+
     const gtmScript = await page.locator('script[id="gtm-script"]').count()
     expect(gtmScript).toBeGreaterThan(0)
 
@@ -122,6 +124,9 @@ test.describe('Google Tag Manager Configuration', () => {
     // The GTM_ID is hardcoded in the component (not from environment variable)
 
     await page.goto('/')
+
+    // GTM uses lazyOnload — wait for the script element to be injected
+    await page.waitForSelector('script#gtm-script', { state: 'attached', timeout: 15000 })
 
     // GTM script should always be present with the hardcoded ID
     const gtmScript = await page.locator('script[id="gtm-script"]').count()


### PR DESCRIPTION
## Summary
- **Consent Mode v2 (#114):** set Google's standard `gtag('consent', 'default', …)` denied-by-default signals inline in `<head>` before GTM loads, and update them via `gtag('consent', 'update', …)` from the cookie consent banner. This is what Google's ad/analytics measurement (now used by Majority Strategies) expects under consent.
- **Structured data (#115):** add `NGO` JSON-LD site-wide and `Event` JSON-LD on the home page for the 2026 Central Pennsylvania Independence Day Parade so the nonprofit and the event can surface correctly in search.
- Fixed two pre-existing flaky GTM E2E tests by waiting for the `lazyOnload`-injected script instead of racing it.

## Details

**Consent Mode v2** (`src/app/layout.tsx`, `src/components/cookie-consent/index.tsx`):
- New inline script in `<head>` declares the standard `gtag()` function and sets `ad_storage`, `ad_user_data`, `ad_personalization`, `analytics_storage` to `denied` by default (with `functionality_storage` and `security_storage` granted). Runs before GTM.
- `applyConsent` now calls `window.gtag('consent', 'update', …)` mapping `prefs.analytics` → `analytics_storage` and `prefs.marketing` → the three ad signals, in addition to the existing custom `consent_update` dataLayer event.

**Structured data** (`src/components/structured-data/index.tsx`, `src/app/layout.tsx`, `src/app/page.tsx`):
- `OrganizationJsonLd` (NGO) rendered in the layout head — name, url, logo, address, email/phone, social `sameAs`.
- `ParadeEventJsonLd` rendered on the home page — name, description, `startDate` 2026-07-04T11:00-04:00, `endDate` 13:00, eventStatus, location, organizer.

## Test plan
- [x] `npm run lint` — clean (only pre-existing `<img>` warnings)
- [x] `npm test` — 25 unit tests pass
- [x] `npm run build` — static export succeeds; verified `consent', 'default'` and both JSON-LD blocks present in `out/index.html`; Org markup present on `out/cookie-policy.html` (site-wide); Event markup is home-only; both JSON-LD blocks parse as valid JSON
- [x] `npm run test:e2e` — 14 cookie-consent tests pass; all 5 GTM tests pass (previously 2 flaky, now deterministic)

Refs #114, #115

https://claude.ai/code/session_01CxBGCCV6UisEj2nXoP9y2m

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxBGCCV6UisEj2nXoP9y2m)_