### PR TITLE
fix: update Facebook footer link to canonical profile URL

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -11,7 +11,11 @@ import { FaXTwitter } from 'react-icons/fa6'
 const Footer: React.FC = () => {
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
   const socialLinks = [
-    { icon: FaFacebookF, href: 'https://www.facebook.com/freedomrisingusa', label: 'Facebook' },
+    {
+      icon: FaFacebookF,
+      href: 'https://www.facebook.com/people/Freedom-Rising-USA/61586331055577/',
+      label: 'Facebook',
+    },
     { icon: FaXTwitter, href: 'https://x.com/USFreedomRising', label: 'X (Twitter)' },
     {
       icon: FaLinkedinIn,

--- a/tests/social-links.spec.ts
+++ b/tests/social-links.spec.ts
@@ -28,7 +28,7 @@ test.describe('Footer Social Links', () => {
     await page.goto('/')
 
     // Verify Facebook link is present
-    const facebookLink = page.locator('footer a[href*="facebook.com/freedomrisingusa"]')
+    const facebookLink = page.locator('footer a[href*="facebook.com/people/Freedom-Rising-USA"]')
     await expect(facebookLink).toBeVisible()
     await expect(facebookLink).toHaveAttribute('aria-label', 'Facebook')
 


### PR DESCRIPTION
## Summary

- The footer linked to `https://www.facebook.com/freedomrisingusa`, but that vanity URL is not registered for the Freedom Rising USA Facebook presence and redirects logged-out visitors to a Facebook login wall.
- Replace it with the canonical profile URL that the share link (`https://www.facebook.com/share/18desXLxNB/`) resolves to: `https://www.facebook.com/people/Freedom-Rising-USA/61586331055577/` ("Freedom Rising USA | State College PA"), which works for everyone.
- Update the Playwright selector in `tests/social-links.spec.ts` to match.

Refs #120 (the proper long-term fix is to convert the profile to a Facebook Page so we can use the `/freedomrisingusa` vanity URL).

## Test plan

- [x] `npm run format` clean
- [x] `npm run lint` clean (only pre-existing image warnings)
- [x] `npm test` — 25/25 passing
- [x] `npm run build` — static export succeeds
- [x] Manually verified the canonical URL returns 200 with `og:title` "Freedom Rising USA | State College PA"

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hqf75qesu9wQrvRnLfCSqh)_