### PR TITLE
fix: correct address to 1950 Pine Hall Rd Suite 90, 16801

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12793,6 +12793,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -157,7 +157,7 @@ const Footer: React.FC = () => {
             </div>
 
             <a
-              href="https://www.google.com/maps/search/?api=1&query=State+College+PA+16803"
+              href="https://www.google.com/maps/search/?api=1&query=1950+Pine+Hall+Rd+Suite+90+State+College+PA+16801"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Open address in Google Maps"
@@ -167,7 +167,7 @@ const Footer: React.FC = () => {
               <div>
                 <p className="font-[500] text-[22px]">Address</p>
                 <p className="font-[500] text-[16px]" id="aria-font">
-                  State College, PA 16803
+                  1950 Pine Hall Rd Suite 90, State College, PA 16801
                 </p>
               </div>
             </a>

--- a/src/data/fundraising-events.ts
+++ b/src/data/fundraising-events.ts
@@ -18,7 +18,7 @@ export const fishFry: FishFryEvent = {
   title: 'Lent Friday Fish Fry',
   description:
     "Join us for our annual Lent Friday Fish Fry fundraising event! Enjoy delicious fish and chips while supporting Freedom Rising USA's mission.",
-  location: 'American Legion Post 245, 1950 Pine Hall Rd, State College, PA 16801',
+  location: 'American Legion Post 245, 1950 Pine Hall Rd Suite 90, State College, PA 16801',
   pickupTime: 'Fridays during Lent, 4:30 PM \u2013 5:30 PM',
   dates: [
     { label: 'Fri, Feb 20', time: '4:30 \u2013 5:30 PM' },

--- a/tests/fundraising-events.spec.ts
+++ b/tests/fundraising-events.spec.ts
@@ -59,7 +59,7 @@ test.describe('Fundraising Events Section', () => {
     // Verify location information
     await expect(fundraisingEventsSection).toContainText('Location:')
     await expect(fundraisingEventsSection).toContainText(
-      'American Legion Post 245, 1950 Pine Hall Rd, State College, PA 16801'
+      'American Legion Post 245, 1950 Pine Hall Rd Suite 90, State College, PA 16801'
     )
 
     // Verify timing information


### PR DESCRIPTION
## Summary

- Correct footer ZIP from `16803` → `16801` (verified incorrect via LoopNet, Yelp, city-data, and USPS PostcodeBase — Pine Hall Rd is in 16801, not 16803)
- Add full street address + `Suite 90` to footer (previously only showed city/state/ZIP)
- Add `Suite 90` to fish fry event location in `src/data/fundraising-events.ts`
- Update footer Google Maps link to point to the full street address
- Update matching Playwright assertion in `tests/fundraising-events.spec.ts`

Final address across the site: `1950 Pine Hall Rd Suite 90, State College, PA 16801`.

Suite 90 confirmed by site owner. Pine Hall Cemetery references (a separate location) were not touched.

## Test plan

- [x] `npm run format` — clean
- [x] `npm run lint` — only pre-existing image warnings
- [x] `npm test` — 25/25 passing
- [x] `npm run build` — static export succeeds
- [ ] Verify footer renders new address on deployed site
- [ ] Verify footer Google Maps link opens the correct location
- [ ] Verify fish fry section displays new location string

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT7rvhotNfLrvKwdwo9Fze)_