### PR TITLE
fix: standardize canonical domain on freedomrisingusa.org

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-ffcworkingsite1.org
+freedomrisingusa.org

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from 'next'
 export const dynamic = 'force-static'
 
 export default function robots(): MetadataRoute.Robots {
-  const base = 'https://ffcworkingsite1.org'
+  const base = 'https://freedomrisingusa.org'
   return {
     rules: {
       userAgent: '*',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from 'next'
 export const dynamic = 'force-static'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://ffcworkingsite1.org'
+  const baseUrl = 'https://freedomrisingusa.org'
   const now = new Date()
   return [
     {

--- a/src/lib/assetPath.ts
+++ b/src/lib/assetPath.ts
@@ -4,7 +4,7 @@
  * When deployed to GitHub Pages at freeforcharity.github.io/FFC_Single_Page_Template/,
  * all assets need to be prefixed with the repository name.
  *
- * For the custom domain (ffcworkingsite1.org), no basePath is needed.
+ * For the custom domain (freedomrisingusa.org), no basePath is needed.
  *
  * @param path - The asset path starting with /
  * @returns The full asset path including basePath if configured

--- a/src/lib/assetPath.ts
+++ b/src/lib/assetPath.ts
@@ -1,7 +1,7 @@
 /**
  * Helper function to construct asset paths that work with GitHub Pages basePath
  *
- * When deployed to GitHub Pages at freeforcharity.github.io/FFC_Single_Page_Template/,
+ * When deployed to GitHub Pages at freeforcharity.github.io/FFC-EX-freedomrisingusa.org/,
  * all assets need to be prefixed with the repository name.
  *
  * For the custom domain (freedomrisingusa.org), no basePath is needed.


### PR DESCRIPTION
## Summary

While verifying the social-share work, I found the site's domain configuration was internally inconsistent — and pointing search engines at the wrong site.

**What's actually live (verified via HTTP):**
| Domain | Serves | `og-image.png` |
|--------|--------|----------------|
| `freedomrisingusa.org` | **This** Freedom Rising site (GitHub Pages, `server: GitHub.com`) | ✅ 200 |
| `ffcworkingsite1.org` | The **Free For Charity corporate** site (via Cloudflare) | ❌ 404 |

`freedomrisingusa.org`'s DNS already resolves to GitHub Pages and serves this repo, and it matches `metadataBase` / the canonical URL in `layout.tsx`. But the GitHub Pages `CNAME`, `sitemap.ts`, and `robots.ts` still pointed at `ffcworkingsite1.org`, which never reaches this deployment. The net effect: the live `robots.txt` and `sitemap.xml` were advertising the wrong host to crawlers, splitting SEO signals across two domains.

## Changes

- `public/CNAME`: `ffcworkingsite1.org` → `freedomrisingusa.org` (already resolves to Pages, so this makes it the official custom domain and enables proper HTTPS/redirect handling)
- `src/app/sitemap.ts`: base URL → `freedomrisingusa.org`
- `src/app/robots.ts`: base URL (and `Sitemap:` line) → `freedomrisingusa.org`
- `src/lib/assetPath.ts`: fixed a stale custom-domain reference in the doc comment

## Verification

Build output now consistently uses the canonical domain:

```
out/CNAME            -> freedomrisingusa.org
robots.txt Sitemap:  -> https://freedomrisingusa.org/sitemap.xml
sitemap.xml <loc>    -> https://freedomrisingusa.org/
```

- `npm run format` clean · `npm run lint` 0 errors · `npm test` 25 passed · `npm run build` OK

## Notes / follow-ups (out of scope)

- Numerous Markdown docs (`README.md`, `DEPLOYMENT.md`, `CONTRIBUTING.md`, etc.) still reference `ffcworkingsite1.org`. These are non-functional and left for a separate docs cleanup to keep this PR focused.
- `sitemap.ts` only lists `/` and `/parade-brief` even though the site has more routes (cookie-policy, privacy-policy, terms-of-service, etc.) — pre-existing and out of scope here.
- After deploy, GitHub Pages will re-verify the custom domain; since `freedomrisingusa.org` already points at Pages this should be seamless, but worth confirming the domain shows "verified" with HTTPS enforced in repo Settings → Pages.

Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_