### PR TITLE
test: stabilize flaky E2E tests (cookie-consent + GTM)

### DIFF
--- a/tests/cookie-consent.spec.ts
+++ b/tests/cookie-consent.spec.ts
@@ -15,9 +15,9 @@ test.describe('Cookie Consent Banner', () => {
   test.beforeEach(async ({ page, context }) => {
     // Clear cookies and localStorage before each test
     await context.clearCookies()
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     await page.evaluate(() => localStorage.clear())
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
   })
 
   test('should display cookie consent banner on first visit', async ({ page }) => {
@@ -68,7 +68,7 @@ test.describe('Cookie Consent Banner', () => {
     await page.getByRole('button', { name: 'Accept All' }).click()
 
     // Reload the page
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
 
     // Banner should not be visible
     const banner = page.locator('[role="region"][aria-label="Cookie consent notice"]')
@@ -91,7 +91,7 @@ test.describe('Cookie Consent Banner', () => {
     await page.getByRole('button', { name: 'Decline All' }).click()
 
     // Reload the page
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
 
     // Banner should not be visible
     const banner = page.locator('[role="region"][aria-label="Cookie consent notice"]')
@@ -112,9 +112,9 @@ test.describe('Cookie Preferences Modal', () => {
   test.beforeEach(async ({ page, context }) => {
     // Clear cookies and localStorage before each test
     await context.clearCookies()
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     await page.evaluate(() => localStorage.clear())
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
   })
 
   test('should open preferences modal when clicking Customize', async ({ page }) => {
@@ -274,7 +274,7 @@ test.describe('Cookie Preferences Modal', () => {
     expect(preferences.marketing).toBe(false)
 
     // Reload and verify banner doesn't appear
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
     await expect(banner).not.toBeVisible()
   })
 })
@@ -282,9 +282,9 @@ test.describe('Cookie Preferences Modal', () => {
 test.describe('Cookie Consent Accessibility', () => {
   test.beforeEach(async ({ page, context }) => {
     await context.clearCookies()
-    await page.goto('/')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     await page.evaluate(() => localStorage.clear())
-    await page.reload()
+    await page.reload({ waitUntil: 'domcontentloaded' })
   })
 
   test('modal should have proper ARIA attributes', async ({ page }) => {

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -25,12 +25,13 @@ test.describe('Google Tag Manager Integration', () => {
   test('should load GTM script with correct ID', async ({ page }) => {
     await page.goto('/')
 
-    // Check for GTM script element
-    const gtmScript = await page.locator('script[id="gtm-script"]').count()
-    expect(gtmScript).toBeGreaterThan(0)
+    // The GTM <Script> uses Next.js strategy="lazyOnload", so the element is
+    // injected client-side after load. Wait for it instead of counting immediately.
+    const gtmScript = page.locator('script[id="gtm-script"]')
+    await expect(gtmScript).toHaveCount(1)
 
     // Verify script contains GTM initialization code
-    const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
+    const scriptContent = await gtmScript.innerHTML()
     expect(scriptContent).toContain('googletagmanager.com/gtm.js')
     expect(scriptContent).toContain('dataLayer')
   })
@@ -123,14 +124,12 @@ test.describe('Google Tag Manager Configuration', () => {
 
     await page.goto('/')
 
-    // GTM script should always be present with the hardcoded ID
-    const gtmScript = await page.locator('script[id="gtm-script"]').count()
-
-    // Script should be present
-    expect(gtmScript).toBeGreaterThan(0)
+    // strategy="lazyOnload" injects the script after load; wait for it.
+    const gtmScript = page.locator('script[id="gtm-script"]')
+    await expect(gtmScript).toHaveCount(1)
 
     // Verify the script contains the correct GTM ID
-    const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
+    const scriptContent = await gtmScript.innerHTML()
     expect(scriptContent).toContain('GTM-K46LNVH2')
   })
 })


### PR DESCRIPTION
## Summary

Stabilizes the two sources of intermittent E2E failures seen across recent PR runs. Both are timing races against client-side behavior, not product bugs.

### 1. Cookie-consent navigations (3 tests)

`page.reload()` / `page.goto()` default to `waitUntil: 'load'`, which blocks until *all* subresources finish — including third-party scripts (GTM, Zeffy, Google Fonts, ffcsites preconnects). On the local `serve -s out` preview those can hang, so the navigation occasionally never sees `load` within 30s.

→ Switched all `goto()` / `reload()` calls in `tests/cookie-consent.spec.ts` to `waitUntil: 'domcontentloaded'`; the banner renders client-side from `localStorage`, so the existing auto-waiting `expect(...)` assertions handle render timing.

### 2. GTM script-presence assertions (2 tests)

The GTM `<Script>` uses Next.js `strategy="lazyOnload"`, so `script[id="gtm-script"]` is injected client-side *after* the load event. Two tests called `.count()` immediately after `page.goto()`, racing the injection (`should load GTM script with correct ID` / `with hardcoded ID` — this caused the `Test and Build` failure on #134's CI).

→ Replaced the immediate `.count()` checks with auto-waiting `expect(locator).toHaveCount(1)` in `tests/google-tag-manager.spec.ts`.

## Verification

```
cookie-consent.spec.ts  --repeat-each=3  → 42 passed, 0 flakes
google-tag-manager.spec.ts --repeat-each=5 → 30 passed, 0 flakes
```

All five previously-flaky tests now pass repeatedly.

_Surfaced while working on the social-share-image issue (#130); not part of #130, so no issue is linked._

🤖 Generated with [Claude Code](https://claude.com/claude-code)