### PR TITLE
perf: lazy-load below-the-fold team member images

### DIFF
--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -27,7 +27,7 @@ export default function TeamMemberCard({
             fill
             className="object-cover"
             sizes="(max-width: 768px) 100vw, 192px"
-            priority
+            loading="lazy"
           />
         </div>
 


### PR DESCRIPTION
## Summary

Picks up the stalled `perf-lazy-images` work from a prior session (which never pushed any commits) and lands a focused image-loading performance fix.

The team section (`TheFreeForCharityTeam`) renders at the very bottom of the home page, well below the fold. Each `TeamMemberCard` avatar was using `priority`, which forces all 5+ team photos (300×300) to eager-load with `fetchpriority="high"` on initial page load. This competes with the LCP hero image for bandwidth and hurts initial load performance — the opposite of what lazy loading is meant to achieve.

## Change

- `src/components/ui/TeamMemberCard.tsx`: replace `priority` with `loading="lazy"` on the avatar `<Image>`, matching the existing convention already used in `SupportFreeForCharity` and `Volunteer-with-Us`.

The true LCP image (the Hero logo) correctly keeps `priority` and is unchanged.

## Verification

Confirmed in the static build output (`out/index.html`): team avatars now render with `loading="lazy" decoding="async"` instead of being eagerly fetched; the Hero image retains `fetchPriority="high"`.

Full pre-commit checklist passes:

- `npm run format` — clean
- `npm run lint` — no new issues (2 pre-existing `<img>` warnings only)
- `npm test` — 25 passed
- `npm run build` — static export succeeds
- `npm run test:e2e` — 57 passed, 17 skipped (incl. `image-loading.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF97DH1ASZ9AaWqBXNuGbK)_