### PR TITLE
fix(seo): include all routes in sitemap.xml

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,18 +5,30 @@ export const dynamic = 'force-static'
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://freedomrisingusa.org'
   const now = new Date()
-  return [
-    {
-      url: `${baseUrl}/`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/parade-brief`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
+
+  type Entry = {
+    path: string
+    changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']
+    priority: number
+  }
+
+  // Keep this list in sync with the routes under src/app/**/page.tsx
+  const routes: Entry[] = [
+    { path: '/', changeFrequency: 'weekly', priority: 1 },
+    { path: '/parade-brief', changeFrequency: 'monthly', priority: 0.8 },
+    { path: '/parade-registration', changeFrequency: 'monthly', priority: 0.8 },
+    { path: '/cookie-policy', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/donation-policy', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/terms-of-service', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/security-acknowledgements', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/vulnerability-disclosure-policy', changeFrequency: 'yearly', priority: 0.3 },
   ]
+
+  return routes.map(({ path, changeFrequency, priority }) => ({
+    url: `${baseUrl}${path}`,
+    lastModified: now,
+    changeFrequency,
+    priority,
+  }))
 }


### PR DESCRIPTION
## Summary

The generated `sitemap.xml` only listed **2 of the site's 9 routes** (`/` and `/parade-brief`), so search engines weren't being pointed at most of the site — including the `parade-registration` page and all the policy/legal pages. This complements the canonical-domain fix (#133): now both the domain *and* the route coverage are correct.

## Changes

`src/app/sitemap.ts` now emits an entry for every route under `src/app/**/page.tsx`:

| Route | Priority | Change freq |
|-------|----------|-------------|
| `/` | 1.0 | weekly |
| `/parade-brief` | 0.8 | monthly |
| `/parade-registration` | 0.8 | monthly |
| `/cookie-policy` | 0.3 | yearly |
| `/donation-policy` | 0.3 | yearly |
| `/privacy-policy` | 0.3 | yearly |
| `/terms-of-service` | 0.3 | yearly |
| `/security-acknowledgements` | 0.3 | yearly |
| `/vulnerability-disclosure-policy` | 0.3 | yearly |

Refactored to a single route list mapped to entries, so adding future pages is a one-line change. A comment flags that the list should stay in sync with `src/app`.

## Verification

```
out/sitemap.xml now contains all 9 <loc> entries, all on https://freedomrisingusa.org
```
- `npm run lint` — 0 errors · `npm run format:check` — clean · `npm test` — 25 passed · `npm run build` — OK

_Follow-up from the domain-standardization work (#133); surfaced during the broader cleanup that began with #130._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_