### PR TITLE
docs: update stale ffcworkingsite1.org references to canonical domains

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -5,5 +5,5 @@ github: FreeForCharity
 
 # Custom funding links (displayed in addition to GitHub Sponsors)
 custom:
-  - 'https://ffcworkingsite1.org'
-  - 'https://ffcworkingsite1.org/#donate'
+  - 'https://freedomrisingusa.org'
+  - 'https://freedomrisingusa.org/#donate'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/FreeForCharity/FFC_Single_Page_Template/blob/main/CONTRIBUTING.md
     about: Learn how to contribute to the project
   - name: 🌐 Free For Charity Website
-    url: https://freedomrisingusa.org
+    url: https://freeforcharity.org
     about: Visit the Free For Charity website

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/FreeForCharity/FFC_Single_Page_Template/blob/main/CONTRIBUTING.md
     about: Learn how to contribute to the project
   - name: 🌐 Free For Charity Website
-    url: https://ffcworkingsite1.org
+    url: https://freedomrisingusa.org
     about: Visit the Free For Charity website

--- a/.github/ISSUE_TEMPLATE/reviewer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/reviewer-onboarding.md
@@ -38,7 +38,7 @@ Please check all areas you reviewed:
 
 ## Review Environment
 
-**Live Site URL:** [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+**Live Site URL:** [https://freedomrisingusa.org](https://freedomrisingusa.org)
 
 **Browser(s) Used:**
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -37,7 +37,7 @@ If you're using this template, we'd love to hear from you! Add your organization
 
 ## Adopters List
 
-### [Free For Charity](https://ffcworkingsite1.org)
+### [Free For Charity](https://freeforcharity.org)
 
 - **Type**: 501(c)(3) Nonprofit Organization
 - **Location**: Tucson, Arizona, USA

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     email: contact@freedomrisingusa.org
     affiliation: Free For Charity
 repository-code: 'https://github.com/FreeForCharity/FFC_Single_Page_Template'
-url: 'https://ffcworkingsite1.org'
+url: 'https://freedomrisingusa.org'
 abstract: >-
   Single-page Next.js 16.0.7 website template built with App
   Router for Free For Charity nonprofit organization. This

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     family-names: Moyer
     email: contact@freedomrisingusa.org
     affiliation: Free For Charity
-repository-code: 'https://github.com/FreeForCharity/FFC_Single_Page_Template'
+repository-code: 'https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org'
 url: 'https://freedomrisingusa.org'
 abstract: >-
   Single-page Next.js 16.0.7 website template built with App

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ This approach helps you:
 
 Start by exploring the live Free For Charity website:
 
-- **Production Site:** [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+- **Production Site:** [https://freedomrisingusa.org](https://freedomrisingusa.org)
 - **GitHub Pages:** [https://freeforcharity.github.io/FFC_Single_Page_Template/](https://freeforcharity.github.io/FFC_Single_Page_Template/)
 
 #### Step 2: Comprehensive Evaluation
@@ -333,7 +333,7 @@ Starting your contribution journey with a fresh review:
 
 ### Ready to Review?
 
-1. Visit [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+1. Visit [https://freedomrisingusa.org](https://freedomrisingusa.org)
 2. Explore thoroughly and take notes
 3. [Create your review issue](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
 4. Report individual issues you discover

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -20,7 +20,7 @@ This document explains how the Free For Charity website is deployed to GitHub Pa
 The Free For Charity website is a static Next.js application deployed to GitHub Pages. The site is accessible at:
 
 - **GitHub Pages URL**: https://freeforcharity.github.io/FFC_Single_Page_Template/
-- **Custom Domain**: https://ffcworkingsite1.org
+- **Custom Domain**: https://freedomrisingusa.org
 
 ### Technology Stack
 
@@ -207,7 +207,7 @@ If using a custom domain:
 1. **Add a CNAME file** to the `public` directory with your domain:
 
    ```
-   ffcworkingsite1.org
+   freedomrisingusa.org
    ```
 
 2. **Configure DNS records** at your domain provider:

--- a/ISSUE_RESOLUTION.md
+++ b/ISSUE_RESOLUTION.md
@@ -423,7 +423,7 @@ npm run test:e2e
    ```bash
    # Should be in public/CNAME
    cat public/CNAME
-   # Should contain: ffcworkingsite1.org
+   # Should contain: freedomrisingusa.org
    ```
 
 ### Issue: Images Load Locally but Not in Production

--- a/NAMING_CONVENTIONS.md
+++ b/NAMING_CONVENTIONS.md
@@ -52,9 +52,9 @@ Kebab-case is the industry standard for SEO-friendly URLs and is explicitly reco
 **Examples:**
 
 ```
-✅ Good: https://ffcworkingsite1.org/cookie-policy
-❌ Bad:  https://ffcworkingsite1.org/CookiePolicy
-❌ Bad:  https://ffcworkingsite1.org/cookiepolicy
+✅ Good: https://freedomrisingusa.org/cookie-policy
+❌ Bad:  https://freedomrisingusa.org/CookiePolicy
+❌ Bad:  https://freedomrisingusa.org/cookiepolicy
 ```
 
 ### 3. Industry Standards

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The site is live and fully functional with the following features:
 - Social media links configured (Facebook, Twitter/X, LinkedIn, GitHub)
 - Footer links fully functional with proper destinations
 - Contact information complete (email, phone, addresses)
-- Deployed to live domain: [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+- Deployed to live domain: [https://freedomrisingusa.org](https://freedomrisingusa.org)
 - Dual deployment: Custom domain and GitHub Pages
 
 ⚠️ **Known Limitations:**
@@ -464,7 +464,7 @@ Both platforms provide identical workflows:
 
 **Coexistence with GitHub Pages:**
 
-- Keep GitHub Pages for production (ffcworkingsite1.org)
+- Keep GitHub Pages for production (freedomrisingusa.org)
 - Use Cloudflare Pages or Vercel for PR previews only
 - No conflicts between systems
 
@@ -635,7 +635,7 @@ The site is configured for static export and deployed to GitHub Pages:
 
 **Production:**
 
-- Live at: [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+- Live at: [https://freedomrisingusa.org](https://freedomrisingusa.org)
 - GitHub Pages URL: [https://freeforcharity.github.io/FFC_Single_Page_Template/](https://freeforcharity.github.io/FFC_Single_Page_Template/)
 - Deployment: Automatic via GitHub Actions (`.github/workflows/deploy.yml`)
 - Trigger: Push to `main` branch
@@ -673,7 +673,7 @@ We welcome new contributors and believe fresh perspectives are invaluable! **You
 
 #### How to Get Started
 
-1. **Explore the live site:** [https://ffcworkingsite1.org](https://ffcworkingsite1.org)
+1. **Explore the live site:** [https://freedomrisingusa.org](https://freedomrisingusa.org)
 2. **Test thoroughly:** Try all features, navigation, and responsive behavior
 3. **Document findings:** Create a review issue using our template
 4. **Report issues:** File separate issues for bugs and enhancements you discover

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ If you have general questions about using this template or Free For Charity's se
 
 - **Email**: contact@freedomrisingusa.org
 - **Phone**: 520-222-8104 (text preferred)
-- **Website**: [freeforcharity.org](https://ffcworkingsite1.org)
+- **Website**: [freeforcharity.org](https://freeforcharity.org)
 
 ### For Technical Issues
 
@@ -62,11 +62,11 @@ Free For Charity offers various services to nonprofits:
 - **Microsoft 365 Grants**: Assistance with Microsoft nonprofit programs
 - **Consulting Services**: Technical guidance and support
 
-**To apply for services**: Visit our [website](https://ffcworkingsite1.org) and click "Apply for Services" or contact us directly.
+**To apply for services**: Visit our [website](https://freeforcharity.org) and click "Apply for Services" or contact us directly.
 
 ## 🔗 Additional Resources
 
-- **Organization Website**: [ffcworkingsite1.org](https://ffcworkingsite1.org)
+- **Organization Website**: [freeforcharity.org](https://freeforcharity.org)
 - **GitHub Organization**: [@FreeForCharity](https://github.com/FreeForCharity)
 - **EIN**: 46-2471893 (501(c)(3) nonprofit)
 

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -18,7 +18,7 @@ The Free For Charity website is a static Next.js application deployed to GitHub 
 
 2. **Hosting and Deployment**
    - GitHub Pages (static hosting)
-   - Custom domain: ffcworkingsite1.org
+   - Custom domain: freedomrisingusa.org
    - GitHub Actions CI/CD pipeline
 
 3. **Development Pipeline**

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'ffcworkingsite1.org',
+        hostname: 'freedomrisingusa.org',
       },
       {
         protocol: 'https',

--- a/src/components/google-tag-manager/README.md
+++ b/src/components/google-tag-manager/README.md
@@ -115,7 +115,7 @@ Test coverage includes:
 
 The site automatically deploys to GitHub Pages via `.github/workflows/nextjs.yml`. The GTM implementation works on both:
 
-1. **Custom domain**: https://www.ffcworkingsite1.org
+1. **Custom domain**: https://www.freedomrisingusa.org
 2. **GitHub Pages**: https://freeforcharity.github.io/FFC_Single_Page_Template/
 
 The GTM ID is hardcoded in the component, so no additional configuration is needed for deployment.


### PR DESCRIPTION
## Summary

Follow-up to the canonical-domain switch (#133). The docs still referenced `ffcworkingsite1.org` as the live site — but that domain now serves the **Free For Charity corporate site**, not this one (verified via live HTTP). This corrects the stale references, distinguishing two cases that a blanket find-replace would have conflated:

### This project → `https://freedomrisingusa.org`
Live-site / production / custom-domain / example-URL references in:
`README.md`, `DEPLOYMENT.md`, `CONTRIBUTING.md`, `THREAT-MODEL.md`, `NAMING_CONVENTIONS.md`, `ISSUE_RESOLUTION.md`, `CITATION.cff`, `.github/ISSUE_TEMPLATE/config.yml`, `.github/ISSUE_TEMPLATE/reviewer-onboarding.md`, `.github/FUNDING.yml`, `src/components/google-tag-manager/README.md`, and the `next.config.ts` image `remotePattern` hostname.

### Free For Charity *org* → `https://freeforcharity.org`
References that are about the parent org, not this site — `ADOPTERS.md` (FFC adopter listing) and `SUPPORT.md` (applying to FFC for services / FFC website). Pointed at FFC's canonical domain; this also fixes a pre-existing text/URL mismatch in `SUPPORT.md` where the link text already read "freeforcharity.org".

## Intentionally left out (infra decision)

`CLOUDFLARE_SETUP.md` and `FACEBOOK_EVENTS_SETUP.md` still reference `ffcworkingsite1.org` — they describe **infrastructure/integration config** (Cloudflare cache rules, Facebook App Domains / privacy-policy URLs) tied to that specific domain. Updating those depends on whether the Cloudflare/Facebook setup is being migrated to `freedomrisingusa.org`, which is a call for the maintainers. Flagging rather than guessing.

## Verification

- No code behavior change (docs + one inert `next.config` image hostname).
- `npm run format:check` clean · `npm run lint` 0 errors · `npm test` 25 passed · `npm run build` OK.
- Confirmed no remaining link-text/URL mismatches.

_Part of the cleanup that began with the social-share-image issue (#130); follows the domain standardization in #133._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_