### PR TITLE
docs: replace template repo name FFC_Single_Page_Template with this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 Get Support
-    url: https://github.com/FreeForCharity/FFC_Single_Page_Template/blob/main/SUPPORT.md
+    url: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/blob/main/SUPPORT.md
     about: Need help? Check our support resources
   - name: 🔒 Report Security Vulnerability
-    url: https://github.com/FreeForCharity/FFC_Single_Page_Template/blob/main/SECURITY.md
+    url: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/blob/main/SECURITY.md
     about: Report security issues privately following our security policy
   - name: 🤝 Contributing Guidelines
-    url: https://github.com/FreeForCharity/FFC_Single_Page_Template/blob/main/CONTRIBUTING.md
+    url: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/blob/main/CONTRIBUTING.md
     about: Learn how to contribute to the project
   - name: 🌐 Free For Charity Website
     url: https://freeforcharity.org

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build site
         run: npm run build
         env:
-          NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+          NEXT_PUBLIC_BASE_PATH: /FFC-EX-freedomrisingusa.org
 
       - name: Run Lighthouse CI
         run: |

--- a/.github/workflows/nextjs.yml.bak
+++ b/.github/workflows/nextjs.yml.bak
@@ -84,7 +84,7 @@ jobs:
         env:
           # Set basePath for GitHub Pages deployment
           # This ensures images and assets work correctly at the subpath
-          NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+          NEXT_PUBLIC_BASE_PATH: /FFC-EX-freedomrisingusa.org
       - name: Run E2E tests
         run: npm run test:e2e
         env:

--- a/.linkinatorrc.json
+++ b/.linkinatorrc.json
@@ -1,6 +1,6 @@
 {
   "skip": [
-    "^https://github.com/(?!FreeForCharity/FFC_Single_Page_Template).*",
+    "^https://github.com/(?!FreeForCharity/FFC-EX-freedomrisingusa.org).*",
     "^http://localhost.*",
     "^https://www.linkedin.com/.*",
     "^https://twitter.com/.*",

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,7 +19,7 @@ If you're using this template, we'd love to hear from you! Add your organization
 1. Fork this repository
 2. Add your entry to the list below
 3. Submit a pull request
-4. Alternatively, [open an issue](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new) with your information
+4. Alternatively, [open an issue](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new) with your information
 
 ## Template
 
@@ -72,7 +72,7 @@ Listing your organization here is entirely voluntary. You may:
 
 If you have questions about adopter listings:
 
-- Open a [GitHub Discussion](https://github.com/FreeForCharity/FFC_Single_Page_Template/discussions)
+- Open a [GitHub Discussion](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/discussions)
 - Email: contact@freedomrisingusa.org
 
 ## Success Stories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,5 +83,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automated testing in CI
 - Merge queue verification
 
-[unreleased]: https://github.com/FreeForCharity/FFC_Single_Page_Template/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/FreeForCharity/FFC_Single_Page_Template/releases/tag/v0.1.0
+[unreleased]: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/releases/tag/v0.1.0

--- a/CODE_QUALITY.md
+++ b/CODE_QUALITY.md
@@ -618,5 +618,5 @@ If you have questions about code quality standards:
 ---
 
 **Last Updated**: 2025-12-03  
-**Repository**: FreeForCharity/FFC_Single_Page_Template  
+**Repository**: FreeForCharity/FFC-EX-freedomrisingusa.org  
 **Node.js**: 20.x (validated with v20.19.6)

--- a/COMMUNITY_HEALTH_FILES.md
+++ b/COMMUNITY_HEALTH_FILES.md
@@ -252,7 +252,7 @@ GitHub displays files in this order:
 
 To verify all community health files are properly recognized:
 
-1. Visit the repository on GitHub: https://github.com/FreeForCharity/FFC_Single_Page_Template
+1. Visit the repository on GitHub: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org
 2. Check for navigation tabs (mobile) or sidebar links (desktop)
 3. Look for the "Sponsor" button (indicates FUNDING.yml is recognized)
 4. Create a new issue to see issue templates
@@ -265,7 +265,7 @@ GitHub provides a community standards checklist at:
 `https://github.com/[owner]/[repo]/community`
 
 For this repository:  
-https://github.com/FreeForCharity/FFC_Single_Page_Template/community
+https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/community
 
 This checklist shows which files are present and recognized.
 
@@ -310,7 +310,7 @@ Follow these conventions:
 For questions about community health files or documentation:
 
 - **Email**: contact@freedomrisingusa.org
-- **Create an issue**: [Documentation issue](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new?template=documentation.md)
+- **Create an issue**: [Documentation issue](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new?template=documentation.md)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ This approach helps you:
 Start by exploring the live Free For Charity website:
 
 - **Production Site:** [https://freedomrisingusa.org](https://freedomrisingusa.org)
-- **GitHub Pages:** [https://freeforcharity.github.io/FFC_Single_Page_Template/](https://freeforcharity.github.io/FFC_Single_Page_Template/)
+- **GitHub Pages:** [https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/](https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/)
 
 #### Step 2: Comprehensive Evaluation
 
@@ -272,7 +272,7 @@ After creating your review issue:
 
 You can create a new reviewer onboarding issue directly using this link:
 
-[**Create Reviewer Onboarding Issue**](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
+[**Create Reviewer Onboarding Issue**](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
 
 ### Tips for a Great Review
 
@@ -335,7 +335,7 @@ Starting your contribution journey with a fresh review:
 
 1. Visit [https://freedomrisingusa.org](https://freedomrisingusa.org)
 2. Explore thoroughly and take notes
-3. [Create your review issue](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
+3. [Create your review issue](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
 4. Report individual issues you discover
 5. Engage with the team on your findings
 
@@ -362,14 +362,14 @@ Starting your contribution journey with a fresh review:
 2. **Clone your fork**:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/FFC_Single_Page_Template.git
-   cd FFC_Single_Page_Template
+   git clone https://github.com/YOUR_USERNAME/FFC-EX-freedomrisingusa.org.git
+   cd FFC-EX-freedomrisingusa.org
    ```
 
 3. **Add upstream remote**:
 
    ```bash
-   git remote add upstream https://github.com/FreeForCharity/FFC_Single_Page_Template.git
+   git remote add upstream https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org.git
    ```
 
 4. **Install dependencies**:
@@ -754,7 +754,7 @@ docs: update contributing guidelines
 
 ### GitHub Issues
 
-- Report bugs and request features through [GitHub Issues](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues)
+- Report bugs and request features through [GitHub Issues](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues)
 - Search existing issues before creating a new one
 - Provide clear, detailed information
 - Use issue templates when available

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -99,7 +99,7 @@ _Last updated: December 13, 2025_
 - **Pull Requests**: See GitHub Insights
 - **Issues Closed**: See GitHub Insights
 
-_Note: For current statistics, visit the repository's [Insights tab](https://github.com/FreeForCharity/FFC_Single_Page_Template/pulse) or [Contributors page](https://github.com/FreeForCharity/FFC_Single_Page_Template/graphs/contributors) on GitHub._
+_Note: For current statistics, visit the repository's [Insights tab](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/pulse) or [Contributors page](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/graphs/contributors) on GitHub._
 
 ## Recognition Guidelines
 
@@ -204,7 +204,7 @@ All contributors are expected to:
 If you have questions about contributor recognition:
 
 - **Email**: contact@freedomrisingusa.org
-- **GitHub Discussions**: [Ask a question](https://github.com/FreeForCharity/FFC_Single_Page_Template/discussions)
+- **GitHub Discussions**: [Ask a question](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/discussions)
 - **Support Guide**: [SUPPORT.md](./SUPPORT.md)
 
 ## Updates to This Document

--- a/DEPENDABOT.md
+++ b/DEPENDABOT.md
@@ -539,6 +539,6 @@ For issues or questions about Dependabot:
 
 **Configuration Version**: 1.0  
 **Last Updated**: 2025-12-03  
-**Repository**: FreeForCharity/FFC_Single_Page_Template  
+**Repository**: FreeForCharity/FFC-EX-freedomrisingusa.org  
 **Node.js**: 20.x (validated with v20.19.6)  
 **Maintained By**: FreeForCharity Team

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,7 +19,7 @@ This document explains how the Free For Charity website is deployed to GitHub Pa
 
 The Free For Charity website is a static Next.js application deployed to GitHub Pages. The site is accessible at:
 
-- **GitHub Pages URL**: https://freeforcharity.github.io/FFC_Single_Page_Template/
+- **GitHub Pages URL**: https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/
 - **Custom Domain**: https://freedomrisingusa.org
 
 ### Technology Stack
@@ -52,7 +52,7 @@ This generates a static site in the `./out` directory that can be served by any 
 
 The site uses the `assetPath()` helper function (located in `src/lib/assetPath.ts`) to handle assets correctly for both:
 
-1. **GitHub Pages subpath deployment**: `/FFC_Single_Page_Template/`
+1. **GitHub Pages subpath deployment**: `/FFC-EX-freedomrisingusa.org/`
 2. **Custom domain deployment**: Root path `/`
 
 The helper uses the `NEXT_PUBLIC_BASE_PATH` environment variable to determine the correct asset path.
@@ -112,7 +112,7 @@ The actual steps performed by the deploy workflow are:
 
 ```yaml
 env:
-  NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+  NEXT_PUBLIC_BASE_PATH: /FFC-EX-freedomrisingusa.org
 ```
 
 This ensures images and assets work correctly at the GitHub Pages subpath.
@@ -141,8 +141,8 @@ While automated deployment is recommended, you can also deploy manually if neede
 1. **Clone the repository** (if not already done):
 
    ```bash
-   git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git
-   cd FFC_Single_Page_Template
+   git clone https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org.git
+   cd FFC-EX-freedomrisingusa.org
    ```
 
 2. **Install dependencies**:
@@ -162,7 +162,7 @@ While automated deployment is recommended, you can also deploy manually if neede
 4. **Build the site** with the correct base path:
 
    ```bash
-   NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template npm run build
+   NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org npm run build
    ```
 
 5. **Verify the build**:
@@ -252,7 +252,7 @@ Environment variables are set in the workflow file:
 - name: Build with Next.js
   run: npm run build
   env:
-    NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+    NEXT_PUBLIC_BASE_PATH: /FFC-EX-freedomrisingusa.org
 ```
 
 ### Local Development
@@ -365,12 +365,12 @@ To test the built site locally before deploying:
 
 ```bash
 # Build with GitHub Pages configuration
-NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template npm run build
+NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org npm run build
 
 # Serve the built site
 npm run preview
 
-# Open http://localhost:3000/FFC_Single_Page_Template in your browser
+# Open http://localhost:3000/FFC-EX-freedomrisingusa.org in your browser
 ```
 
 This simulates how the site will behave on GitHub Pages.

--- a/FACEBOOK_EVENTS_SETUP.md
+++ b/FACEBOOK_EVENTS_SETUP.md
@@ -21,7 +21,7 @@ Before starting implementation, ensure you have:
 - [x] Confirmed Free For Charity Facebook page URL: `https://www.facebook.com/freeforcharity`
 - [x] Verified Facebook page has upcoming events posted
 - [x] Development environment set up (Node.js 20.x, npm)
-- [x] Access to repository: `FreeForCharity/FFC_Single_Page_Template`
+- [x] Access to repository: `FreeForCharity/FFC-EX-freedomrisingusa.org`
 - [x] Reviewed existing cookie consent implementation in `src/components/cookie-consent/index.tsx`
 
 ## Phase 1: Facebook Page Plugin Implementation
@@ -1124,7 +1124,7 @@ Set up monitoring for:
 
 **Technical Issues:**
 
-- Repository: https://github.com/FreeForCharity/FFC_Single_Page_Template/issues
+- Repository: https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues
 - Email: contact@freedomrisingusa.org
 
 **Facebook Developer Support:**

--- a/ISSUE_RESOLUTION.md
+++ b/ISSUE_RESOLUTION.md
@@ -207,7 +207,7 @@ Error: Cannot find module '@/components/Header'
 
    ```bash
    # For GitHub Pages
-   NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template npm run build
+   NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org npm run build
 
    # For custom domain
    npm run build
@@ -416,7 +416,7 @@ npm run test:e2e
    output: 'export'
 
    // Build should use:
-   NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template
+   NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org
    ```
 
 3. **Check CNAME file** (if using custom domain):
@@ -674,7 +674,7 @@ See [LIGHTHOUSE.md](./LIGHTHOUSE.md) for detailed guidance. Quick tips:
 
 ### Where do I report bugs?
 
-1. **Check existing issues** first: [GitHub Issues](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues)
+1. **Check existing issues** first: [GitHub Issues](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues)
 2. **Open a new issue** with:
    - Clear description
    - Steps to reproduce
@@ -700,7 +700,7 @@ If your issue isn't covered here:
 ---
 
 **Last Updated**: 2025-12-03  
-**Repository**: FreeForCharity/FFC_Single_Page_Template  
+**Repository**: FreeForCharity/FFC-EX-freedomrisingusa.org  
 **Node.js**: 20.x (validated with v20.19.6)
 
 _This document is continuously updated. If you solve an issue not listed here, please contribute by adding it!_

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -381,7 +381,7 @@ docs: update README with new deployment instructions
 
 **Challenge**: Images and assets don't load on GitHub Pages deployment
 
-**Root Cause**: GitHub Pages serves the site at `/FFC_Single_Page_Template/` instead of `/`
+**Root Cause**: GitHub Pages serves the site at `/FFC-EX-freedomrisingusa.org/` instead of `/`
 
 **Solution**:
 

--- a/MERGE_QUEUE_VERIFICATION.md
+++ b/MERGE_QUEUE_VERIFICATION.md
@@ -43,7 +43,7 @@ Based on the provided screenshots and GitHub API data, here's what happened when
 - **Status:** ✅ Completed successfully
 - **Workflow:** Deploy to GitHub Pages
 - **Trigger:** `workflow_run` (after CI completed)
-- **Environment Variable:** `NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template`
+- **Environment Variable:** `NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org`
 - **Steps Executed:**
   - Build with Next.js for GitHub Pages
   - Deploy to GitHub Pages environment

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -13,8 +13,8 @@ Get up and running with the FFC Single Page Template in 5 minutes.
 ### 1. Clone the Repository (30 seconds)
 
 ```bash
-git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git
-cd FFC_Single_Page_Template
+git clone https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org.git
+cd FFC-EX-freedomrisingusa.org
 ```
 
 ### 2. Install Dependencies (17 seconds)
@@ -136,7 +136,7 @@ git push origin feature/your-feature-name
 ## Project Structure (Quick Reference)
 
 ```
-FFC_Single_Page_Template/
+FFC-EX-freedomrisingusa.org/
 ├── src/
 │   ├── app/
 │   │   ├── layout.tsx          # Root layout with metadata
@@ -354,8 +354,8 @@ Now that you're set up, check out:
 
 ## Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/FreeForCharity/FFC_Single_Page_Template/discussions)
+- **Issues**: [GitHub Issues](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/discussions)
 - **Documentation**: Check the `*.md` files in the repository root
 
 ---

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Both platforms provide identical workflows:
    - Build command: `npm run build`
    - Build output directory: `out`
    - Environment variables: Leave `NEXT_PUBLIC_BASE_PATH` unset
-     - GitHub Pages needs `/FFC_Single_Page_Template` for subdirectory routing
+     - GitHub Pages needs `/FFC-EX-freedomrisingusa.org` for subdirectory routing
      - Cloudflare Pages deploys to root, no basePath needed
 
 4. **Enable Preview Deployments**
@@ -636,7 +636,7 @@ The site is configured for static export and deployed to GitHub Pages:
 **Production:**
 
 - Live at: [https://freedomrisingusa.org](https://freedomrisingusa.org)
-- GitHub Pages URL: [https://freeforcharity.github.io/FFC_Single_Page_Template/](https://freeforcharity.github.io/FFC_Single_Page_Template/)
+- GitHub Pages URL: [https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/](https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/)
 - Deployment: Automatic via GitHub Actions (`.github/workflows/deploy.yml`)
 - Trigger: Push to `main` branch
 - Build output: Static files in `./out` directory
@@ -682,7 +682,7 @@ We welcome new contributors and believe fresh perspectives are invaluable! **You
 
 Use our **Reviewer Onboarding template** to document your findings:
 
-[**Create Reviewer Onboarding Issue**](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
+[**Create Reviewer Onboarding Issue**](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new?assignees=&labels=documentation%2Creview%2Conboarding&template=reviewer-onboarding.md)
 
 The template guides you through:
 

--- a/RESPONSIVE_DESIGN.md
+++ b/RESPONSIVE_DESIGN.md
@@ -428,6 +428,6 @@ When adding new components or modifying existing ones:
 ---
 
 **Last Updated**: 2025-12-03  
-**Repository**: FreeForCharity/FFC_Single_Page_Template  
+**Repository**: FreeForCharity/FFC-EX-freedomrisingusa.org  
 **Node.js**: 20.x (validated with v20.19.6)  
 **Maintainer**: FreeForCharity Development Team

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -283,7 +283,7 @@ If you discover a security vulnerability in this repository:
 
 1. **Do NOT open a public issue** - this could put the live site at risk
 2. **Report privately** using one of these methods:
-   - **Preferred**: Use GitHub's [Security Advisories feature](https://github.com/FreeForCharity/FFC_Single_Page_Template/security/advisories/new)
+   - **Preferred**: Use GitHub's [Security Advisories feature](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/security/advisories/new)
    - **Alternative**: Email contact@freedomrisingusa.org with subject line "Security Vulnerability Report"
 3. Include as much detail as possible:
    - Description of the vulnerability

--- a/SITE_IMPROVEMENTS.md
+++ b/SITE_IMPROVEMENTS.md
@@ -6,7 +6,7 @@
 
 **Last Updated:** December 2025  
 **Status:** Phase 5 Complete - All Critical Gaps Closed  
-**Repository:** FreeForCharity/FFC_Single_Page_Template  
+**Repository:** FreeForCharity/FFC-EX-freedomrisingusa.org  
 **Node.js:** 20.x (validated with v20.19.6)
 
 ---
@@ -49,7 +49,7 @@ This document is maintained for historical reference and future planning.
 
 ## Executive Summary
 
-This analysis compares FFC_Single_Page_Template against three sister repositories:
+This analysis compares FFC-EX-freedomrisingusa.org against three sister repositories:
 
 - **freeforcharity-web**: Production FFC website (near-identical to current repo)
 - **ffcadmin.org**: Administrative portal with extensive documentation and tooling
@@ -57,7 +57,7 @@ This analysis compares FFC_Single_Page_Template against three sister repositorie
 
 ### Key Findings
 
-**FFC_Single_Page_Template** is a feature-rich, single-page Next.js application with 112 component files and extensive content sections, plus 7 policy pages.
+**FFC-EX-freedomrisingusa.org** is a feature-rich, single-page Next.js application with 112 component files and extensive content sections, plus 7 policy pages.
 
 **Note:** As of Phase 5 completion, most critical gaps have been addressed. The items listed below were the original gaps identified, many of which have now been implemented. However, compared to sister sites, some differences remain:
 
@@ -76,27 +76,27 @@ This analysis compares FFC_Single_Page_Template against three sister repositorie
 
 ### Technology Stack Comparison
 
-| Feature             | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| ------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **Next.js Version** | 16.0.7                   | 15.5.2             | 16.0.3       | 15.4.6   |
-| **React Version**   | 19.1.0                   | 19.1.0             | 19.2.0       | 19.1.0   |
-| **Node.js Target**  | 20.x                     | 20.x               | 20.x         | 20.x     |
-| **Package Manager** | npm                      | npm                | pnpm         | npm      |
-| **Static Export**   | ✅                       | ✅                 | ✅           | ✅       |
-| **TypeScript**      | ✅                       | ✅                 | ✅           | ✅       |
-| **Tailwind CSS**    | ✅ v4.1.12               | ✅ v4.1.12         | ✅ v4.1.17   | ✅ v4    |
+| Feature             | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| ------------------- | --------------------------- | ------------------ | ------------ | -------- |
+| **Next.js Version** | 16.0.7                      | 15.5.2             | 16.0.3       | 15.4.6   |
+| **React Version**   | 19.1.0                      | 19.1.0             | 19.2.0       | 19.1.0   |
+| **Node.js Target**  | 20.x                        | 20.x               | 20.x         | 20.x     |
+| **Package Manager** | npm                         | npm                | pnpm         | npm      |
+| **Static Export**   | ✅                          | ✅                 | ✅           | ✅       |
+| **TypeScript**      | ✅                          | ✅                 | ✅           | ✅       |
+| **Tailwind CSS**    | ✅ v4.1.12                  | ✅ v4.1.12         | ✅ v4.1.17   | ✅ v4    |
 
 ### Dependency Comparison
 
-| Library/Tool         | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| -------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **framer-motion**    | ✅ 12.23.24              | ✅ 12.23.24        | ❌           | ❌       |
-| **lucide-react**     | ✅ 0.469.0               | ✅ 0.469.0         | ❌           | ❌       |
-| **react-icons**      | ✅ 5.5.0                 | ✅ 5.5.0           | ❌           | ❌       |
-| **swiper**           | ✅ 12.0.3                | ✅ 12.0.3          | ❌           | ❌       |
-| **@playwright/test** | ✅ 1.56.0                | ✅ 1.56.0          | ❌           | ❌       |
+| Library/Tool         | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| -------------------- | --------------------------- | ------------------ | ------------ | -------- |
+| **framer-motion**    | ✅ 12.23.24                 | ✅ 12.23.24        | ❌           | ❌       |
+| **lucide-react**     | ✅ 0.469.0                  | ✅ 0.469.0         | ❌           | ❌       |
+| **react-icons**      | ✅ 5.5.0                    | ✅ 5.5.0           | ❌           | ❌       |
+| **swiper**           | ✅ 12.0.3                   | ✅ 12.0.3          | ❌           | ❌       |
+| **@playwright/test** | ✅ 1.56.0                   | ✅ 1.56.0          | ❌           | ❌       |
 
-**Observation:** FFC_Single_Page_Template and freeforcharity-web are nearly identical in their dependency stacks, suggesting they share similar feature sets.
+**Observation:** FFC-EX-freedomrisingusa.org and freeforcharity-web are nearly identical in their dependency stacks, suggesting they share similar feature sets.
 
 ---
 
@@ -293,7 +293,7 @@ module.exports = {
 ### GAP-4: Bundle Size Analysis
 
 **Status:** ⚠️ Partial (config present but not fully utilized)  
-**Present In:** ffcadmin.org (comprehensive), FFC_Single_Page_Template (basic)  
+**Present In:** ffcadmin.org (comprehensive), FFC-EX-freedomrisingusa.org (basic)  
 **Priority:** LOW
 
 #### Current State
@@ -1130,7 +1130,7 @@ export const FORM_CONFIGS: Record<FormType, FormConfig> = {
 ### GAP-14: Cookie Consent with Granular Controls
 
 **Status:** ⚠️ Basic implementation exists  
-**Present In:** KCCF-web (advanced), FFC_Single_Page_Template (basic)  
+**Present In:** KCCF-web (advanced), FFC-EX-freedomrisingusa.org (basic)  
 **Priority:** MEDIUM
 
 #### Current State
@@ -2132,69 +2132,69 @@ trim_trailing_whitespace = false
 
 ### Development Tooling Status
 
-| Feature             | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| ------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **Prettier**        | ✅ 3.7.4                 | ❌                 | ✅ 3.4.2     | ❌       |
-| **Husky**           | ✅ 9.1.7                 | ❌                 | ✅ 9.1.7     | ❌       |
-| **Commitlint**      | ✅ 20.1.0                | ❌                 | ✅ 20.0.1    | ❌       |
-| **.editorconfig**   | ✅ Added                 | ❌                 | ✅           | ❌       |
-| **Linkinator**      | ✅ Latest                | ❌                 | ✅ 7.4.6     | ❌       |
-| **Bundle Analyzer** | ⚠️ Config only           | ⚠️ Config only     | ✅ Active    | ❌       |
+| Feature             | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| ------------------- | --------------------------- | ------------------ | ------------ | -------- |
+| **Prettier**        | ✅ 3.7.4                    | ❌                 | ✅ 3.4.2     | ❌       |
+| **Husky**           | ✅ 9.1.7                    | ❌                 | ✅ 9.1.7     | ❌       |
+| **Commitlint**      | ✅ 20.1.0                   | ❌                 | ✅ 20.0.1    | ❌       |
+| **.editorconfig**   | ✅ Added                    | ❌                 | ✅           | ❌       |
+| **Linkinator**      | ✅ Latest                   | ❌                 | ✅ 7.4.6     | ❌       |
+| **Bundle Analyzer** | ⚠️ Config only              | ⚠️ Config only     | ✅ Active    | ❌       |
 
 ### Testing Infrastructure Status
 
-| Feature                      | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| ---------------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **Jest**                     | ✅ 30.2.0                | ❌                 | ✅ 30.2.0    | ❌       |
-| **React Testing Library**    | ✅ 16.3.0                | ❌                 | ✅ 16.3.0    | ❌       |
-| **jest-axe (Accessibility)** | ✅ 10.0.0                | ❌                 | ✅           | ❌       |
-| **Playwright (E2E)**         | ✅ 1.56.0                | ✅ 1.56.0          | ❌           | ❌       |
-| **Test Coverage**            | ✅ ~5% (25 tests)        | ❌                 | ✅ ~15%      | ❌       |
-| **Coverage Thresholds**      | ✅ Configured            | ❌                 | ✅           | ❌       |
+| Feature                      | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| ---------------------------- | --------------------------- | ------------------ | ------------ | -------- |
+| **Jest**                     | ✅ 30.2.0                   | ❌                 | ✅ 30.2.0    | ❌       |
+| **React Testing Library**    | ✅ 16.3.0                   | ❌                 | ✅ 16.3.0    | ❌       |
+| **jest-axe (Accessibility)** | ✅ 10.0.0                   | ❌                 | ✅           | ❌       |
+| **Playwright (E2E)**         | ✅ 1.56.0                   | ✅ 1.56.0          | ❌           | ❌       |
+| **Test Coverage**            | ✅ ~5% (25 tests)           | ❌                 | ✅ ~15%      | ❌       |
+| **Coverage Thresholds**      | ✅ Configured               | ❌                 | ✅           | ❌       |
 
 ### CI/CD & Security Status
 
-| Feature                          | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| -------------------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **CodeQL Security Scanning**     | ✅ Active                | ❌                 | ✅ Active    | ✅       |
-| **Lighthouse CI**                | ✅ Active                | ❌                 | ✅ Active    | ❌       |
-| **Separate CI/Deploy Workflows** | ✅ Split                 | ❌ Monolithic      | ✅ Split     | ❌       |
-| **Dependabot**                   | ✅ Configured            | ✅                 | ✅           | ✅       |
-| **Link Validation in CI**        | ✅ Ready                 | ❌                 | ✅           | ❌       |
+| Feature                          | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| -------------------------------- | --------------------------- | ------------------ | ------------ | -------- |
+| **CodeQL Security Scanning**     | ✅ Active                   | ❌                 | ✅ Active    | ✅       |
+| **Lighthouse CI**                | ✅ Active                   | ❌                 | ✅ Active    | ❌       |
+| **Separate CI/Deploy Workflows** | ✅ Split                    | ❌ Monolithic      | ✅ Split     | ❌       |
+| **Dependabot**                   | ✅ Configured               | ✅                 | ✅           | ✅       |
+| **Link Validation in CI**        | ✅ Ready                    | ❌                 | ✅           | ❌       |
 
 ### Documentation Status
 
-| Documentation File       | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| ------------------------ | ------------------------ | ------------------ | ------------ | -------- |
-| **README.md**            | ✅                       | ✅                 | ✅           | ✅       |
-| **CONTRIBUTING.md**      | ✅                       | ❌                 | ✅           | ❌       |
-| **TESTING.md**           | ✅                       | ✅                 | ✅           | ❌       |
-| **CODE_QUALITY.md**      | ✅                       | ❌                 | ✅           | ❌       |
-| **SECURITY.md**          | ✅                       | ❌                 | ✅           | ❌       |
-| **DEPLOYMENT.md**        | ✅                       | ❌                 | ✅           | ❌       |
-| **LIGHTHOUSE.md**        | ✅                       | ❌                 | ✅           | ❌       |
-| **ISSUE_RESOLUTION.md**  | ✅                       | ❌                 | ✅           | ❌       |
-| **RESPONSIVE_DESIGN.md** | ✅                       | ❌                 | ✅           | ❌       |
-| **QUICK_START.md**       | ✅                       | ❌                 | ✅           | ❌       |
-| **LESSONS_LEARNED.md**   | ✅                       | ❌                 | ✅           | ❌       |
-| **EXTERNAL_SERVICES.md** | ❌ Not needed            | ❌                 | ❌           | ✅       |
-| **GPG_SIGNING.md**       | ❌ Not implementing      | ❌                 | ✅           | ❌       |
+| Documentation File       | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web |
+| ------------------------ | --------------------------- | ------------------ | ------------ | -------- |
+| **README.md**            | ✅                          | ✅                 | ✅           | ✅       |
+| **CONTRIBUTING.md**      | ✅                          | ❌                 | ✅           | ❌       |
+| **TESTING.md**           | ✅                          | ✅                 | ✅           | ❌       |
+| **CODE_QUALITY.md**      | ✅                          | ❌                 | ✅           | ❌       |
+| **SECURITY.md**          | ✅                          | ❌                 | ✅           | ❌       |
+| **DEPLOYMENT.md**        | ✅                          | ❌                 | ✅           | ❌       |
+| **LIGHTHOUSE.md**        | ✅                          | ❌                 | ✅           | ❌       |
+| **ISSUE_RESOLUTION.md**  | ✅                          | ❌                 | ✅           | ❌       |
+| **RESPONSIVE_DESIGN.md** | ✅                          | ❌                 | ✅           | ❌       |
+| **QUICK_START.md**       | ✅                          | ❌                 | ✅           | ❌       |
+| **LESSONS_LEARNED.md**   | ✅                          | ❌                 | ✅           | ❌       |
+| **EXTERNAL_SERVICES.md** | ❌ Not needed               | ❌                 | ❌           | ✅       |
+| **GPG_SIGNING.md**       | ❌ Not implementing         | ❌                 | ✅           | ❌       |
 
 ### User Experience Features Status
 
-| Feature                         | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web    |
-| ------------------------------- | ------------------------ | ------------------ | ------------ | ----------- |
-| **Dark Mode**                   | ❌ Not implemented       | ❌                 | ❌           | ✅          |
-| **Cookie Consent**              | ✅ Basic                 | ✅ Basic           | ❌           | ✅ Advanced |
-| **Modal/Popup System**          | ✅ Basic (2 modals)      | ✅ Basic           | ❌           | ✅ Advanced |
-| **Theme Context**               | ❌                       | ❌                 | ❌           | ✅          |
-| **Advanced Context Management** | ❌                       | ❌                 | ❌           | ✅          |
+| Feature                         | FFC-EX-freedomrisingusa.org | freeforcharity-web | ffcadmin.org | KCCF-web    |
+| ------------------------------- | --------------------------- | ------------------ | ------------ | ----------- |
+| **Dark Mode**                   | ❌ Not implemented          | ❌                 | ❌           | ✅          |
+| **Cookie Consent**              | ✅ Basic                    | ✅ Basic           | ❌           | ✅ Advanced |
+| **Modal/Popup System**          | ✅ Basic (2 modals)         | ✅ Basic           | ❌           | ✅ Advanced |
+| **Theme Context**               | ❌                          | ❌                 | ❌           | ✅          |
+| **Advanced Context Management** | ❌                          | ❌                 | ❌           | ✅          |
 
 ### Summary of Remaining Gaps
 
 #### Features Not Implemented (By Design)
 
-These features are present in sister repositories but **intentionally not implemented** in FFC_Single_Page_Template:
+These features are present in sister repositories but **intentionally not implemented** in FFC-EX-freedomrisingusa.org:
 
 1. **GPG Commit Signing** (GAP-11) - Per issue requirements, commit bot/auto GPG signing excluded
 2. **Dark Mode** (GAP-12) - Optional feature, not prioritized
@@ -2437,7 +2437,7 @@ These enhancements focus on improving the **user experience** - what visitors se
 
 #### Current Status vs ffcadmin.org (Primary Reference)
 
-**Areas where FFC_Single_Page_Template equals or exceeds ffcadmin.org:**
+**Areas where FFC-EX-freedomrisingusa.org equals or exceeds ffcadmin.org:**
 
 - ✅ Playwright E2E testing (ffcadmin doesn't have this)
 - ✅ Accessibility testing with jest-axe (same)
@@ -2454,7 +2454,7 @@ These enhancements focus on improving the **user experience** - what visitors se
 
 ## Conclusion
 
-This analysis identified 19 technical capability gaps between FFC_Single_Page_Template and its sister repositories. Through 5 implementation phases, we have successfully closed the majority of critical gaps.
+This analysis identified 19 technical capability gaps between FFC-EX-freedomrisingusa.org and its sister repositories. Through 5 implementation phases, we have successfully closed the majority of critical gaps.
 
 ### Implementation Results
 
@@ -2502,7 +2502,7 @@ This analysis identified 19 technical capability gaps between FFC_Single_Page_Te
 
 ### Repository Maturity Status
 
-**FFC_Single_Page_Template** is now a **mature, production-ready template** with:
+**FFC-EX-freedomrisingusa.org** is now a **mature, production-ready template** with:
 
 1. **Enterprise-grade code quality tooling**
    - Automated formatting (Prettier)
@@ -2538,21 +2538,21 @@ This analysis identified 19 technical capability gaps between FFC_Single_Page_Te
 
 **vs freeforcharity-web:**
 
-- ✅ FFC_Single_Page_Template is now **significantly more advanced**
+- ✅ FFC-EX-freedomrisingusa.org is now **significantly more advanced**
 - Added: Testing, code quality tools, documentation, security scanning
 - freeforcharity-web should consider adopting these improvements
 
 **vs ffcadmin.org:**
 
 - ✅ Feature parity achieved in most areas
-- FFC_Single_Page_Template adds: Playwright E2E tests
+- FFC-EX-freedomrisingusa.org adds: Playwright E2E tests
 - ffcadmin.org advantage: Higher test coverage (~15% vs ~5%)
 
 **vs KCCF-web:**
 
 - ✅ Feature parity in infrastructure and tooling
 - KCCF-web advantages: Dark mode, advanced modal system
-- FFC_Single_Page_Template advantages: Testing, code quality automation
+- FFC-EX-freedomrisingusa.org advantages: Testing, code quality automation
 
 ### Future Recommendations
 
@@ -2585,7 +2585,7 @@ This analysis identified 19 technical capability gaps between FFC_Single_Page_Te
 
 **Project Status:** ✅ **Phase 5 Complete - All Critical Gaps Closed**
 
-The FFC_Single_Page_Template is now a **best-in-class Next.js template** with enterprise-grade tooling, comprehensive testing, professional documentation, and robust CI/CD. It meets or exceeds the capabilities of all sister repositories in most areas.
+The FFC-EX-freedomrisingusa.org is now a **best-in-class Next.js template** with enterprise-grade tooling, comprehensive testing, professional documentation, and robust CI/CD. It meets or exceeds the capabilities of all sister repositories in most areas.
 
 **Repository is production-ready and can serve as the foundation for future Free For Charity web projects.**
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,8 +16,8 @@ If you have general questions about using this template or Free For Charity's se
 
 If you encounter technical issues, bugs, or need development help:
 
-1. **Search Existing Issues**: Check if your issue has already been reported in the [Issues](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues) section
-2. **Open a New Issue**: If your issue is new, [create an issue](https://github.com/FreeForCharity/FFC_Single_Page_Template/issues/new) with detailed information:
+1. **Search Existing Issues**: Check if your issue has already been reported in the [Issues](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues) section
+2. **Open a New Issue**: If your issue is new, [create an issue](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/issues/new) with detailed information:
    - Description of the problem
    - Steps to reproduce
    - Expected vs actual behavior

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -6,7 +6,7 @@
 
 **Last Updated:** December 2025  
 **Status:** Active Tracking  
-**Repository:** FreeForCharity/FFC_Single_Page_Template
+**Repository:** FreeForCharity/FFC-EX-freedomrisingusa.org
 
 ---
 
@@ -223,7 +223,7 @@ npm audit fix --force
 - **Scope:** GitHub Actions workflow dependencies
 - **Strategy:** Grouped updates for easier review
 
-**Current Dependabot PRs:** Check [Pull Requests tab](https://github.com/FreeForCharity/FFC_Single_Page_Template/pulls)
+**Current Dependabot PRs:** Check [Pull Requests tab](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/pulls)
 
 ### Pending Dependency Updates
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -299,7 +299,7 @@ Tests that verify image loading works correctly for both custom domain and GitHu
      - Both logos use identical path
    - **Deployment Compatibility**:
      - Custom domain: `/web-app-manifest-512x512.png`
-   - GitHub Pages: `/FFC_Single_Page_Template/web-app-manifest-512x512.png`
+   - GitHub Pages: `/FFC-EX-freedomrisingusa.org/web-app-manifest-512x512.png`
 
 5. **`images should return 200 status code`**
    - **Purpose**: Verifies images load successfully via HTTP
@@ -340,7 +340,7 @@ Tests run automatically in GitHub Actions with the following configuration:
 - **Trigger**: Every push to main branch
 - **Environment**: Ubuntu latest with Node.js 20
 - **Browser Setup**: `npx playwright install --with-deps chromium`
-- **Build**: Built with `NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template`
+- **Build**: Built with `NEXT_PUBLIC_BASE_PATH=/FFC-EX-freedomrisingusa.org`
 - **Retry Logic**: Failed tests retry 2 times
 - **Failure Handling**: Deployment blocked if tests fail
 
@@ -696,7 +696,7 @@ npm audit
 ## File Structure Reference
 
 ```
-FFC_Single_Page_Template/
+FFC-EX-freedomrisingusa.org/
 ├── tests/                          # Test suite
 │   ├── logo.spec.ts               # Logo visibility tests (3 tests)
 │   ├── github-pages.spec.ts       # Deployment compatibility tests (3 tests)

--- a/__tests__/lib/assetPath.test.ts
+++ b/__tests__/lib/assetPath.test.ts
@@ -23,17 +23,17 @@ describe('assetPath utility', () => {
   })
 
   it('should prepend basePath when NEXT_PUBLIC_BASE_PATH is set', () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC_Single_Page_Template'
-    expect(assetPath('/logo.png')).toBe('/FFC_Single_Page_Template/logo.png')
+    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC-EX-freedomrisingusa.org'
+    expect(assetPath('/logo.png')).toBe('/FFC-EX-freedomrisingusa.org/logo.png')
   })
 
   it('should handle paths with subdirectories', () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC_Single_Page_Template'
-    expect(assetPath('/images/hero.jpg')).toBe('/FFC_Single_Page_Template/images/hero.jpg')
+    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC-EX-freedomrisingusa.org'
+    expect(assetPath('/images/hero.jpg')).toBe('/FFC-EX-freedomrisingusa.org/images/hero.jpg')
   })
 
   it('should handle root path', () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC_Single_Page_Template'
-    expect(assetPath('/')).toBe('/FFC_Single_Page_Template/')
+    process.env.NEXT_PUBLIC_BASE_PATH = '/FFC-EX-freedomrisingusa.org'
+    expect(assetPath('/')).toBe('/FFC-EX-freedomrisingusa.org/')
   })
 })

--- a/src/components/google-tag-manager/README.md
+++ b/src/components/google-tag-manager/README.md
@@ -113,10 +113,10 @@ Test coverage includes:
 
 ### GitHub Pages Deployment
 
-The site automatically deploys to GitHub Pages via `.github/workflows/nextjs.yml`. The GTM implementation works on both:
+The site automatically deploys to GitHub Pages via `.github/workflows/deploy.yml`. The GTM implementation works on both:
 
-1. **Custom domain**: https://www.freedomrisingusa.org
-2. **GitHub Pages**: https://freeforcharity.github.io/FFC_Single_Page_Template/
+1. **Custom domain**: https://freedomrisingusa.org
+2. **GitHub Pages**: https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/
 
 The GTM ID is hardcoded in the component, so no additional configuration is needed for deployment.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,7 @@ Tests deployment compatibility for both custom domain and GitHub Pages with base
      - Both logos use identical path
    - **Deployment Scenarios**:
      - ✅ Custom domain: `/web-app-manifest-512x512.png`
-     - ✅ GitHub Pages: `/FFC_Single_Page_Template/web-app-manifest-512x512.png`
+     - ✅ GitHub Pages: `/FFC-EX-freedomrisingusa.org/web-app-manifest-512x512.png`
 
 5. **`images should return 200 status code`**
    - **Purpose**: Verifies images load successfully via HTTP requests
@@ -101,7 +101,7 @@ Tests footer social media links to ensure only active platforms are displayed.
      - ✅ Facebook: `facebook.com/freeforcharity`
      - ✅ X (Twitter): `x.com/freeforcharity1`
      - ✅ LinkedIn: `linkedin.com/company/freeforcharity`
-     - ✅ GitHub: `github.com/FreeForCharity/FFC_Single_Page_Template`
+     - ✅ GitHub: `github.com/FreeForCharity/FFC-EX-freedomrisingusa.org`
 
 9. **`should have exactly 4 social media icons`**
    - **Purpose**: Ensures correct number of social icons are rendered


### PR DESCRIPTION
## Summary

This repo was created from the **`FFC_Single_Page_Template`** template and never had the template repo name updated. As a result, GitHub Pages URLs, repo links, issue-tracker links, the example basePath, and even CI/test config still referenced the template repo. This is the dedicated follow-up promised in #139's review threads.

Replaces `FFC_Single_Page_Template` → `FFC-EX-freedomrisingusa.org` everywhere it denotes this repo (27 files, 144 occurrences):

- **Pages URLs** → `https://freeforcharity.github.io/FFC-EX-freedomrisingusa.org/`
- **Repo links** → `github.com/FreeForCharity/FFC-EX-freedomrisingusa.org`, including the **issue-chooser contact links** (`config.yml`) and the onboarding/review issue links in `SUPPORT.md` / `CONTRIBUTING.md`, so reports land in *this* repo's tracker
- **The fork `upstream` remote** in `CONTRIBUTING.md` (the original value pointed contributors at the template — wrong for contributing here)
- **`NEXT_PUBLIC_BASE_PATH`** in `lighthouse.yml` and `__tests__/lib/assetPath.test.ts` — env value and expected output updated together, so the test still passes

Also fixes the **GTM README** deploy section (separate items Copilot flagged): references the real workflow (`deploy.yml`, not the non-existent `nextjs.yml`) and the canonical host (`freedomrisingusa.org`, dropping `www.`).

## Verification

- `__tests__/lib/assetPath.test.ts` — 5/5 pass with the updated basePath
- `npm test` — 25 passed · `npm run format:check` — clean · `npm run lint` — 0 errors · `npm run build` — OK
- The one risk is `lighthouse.yml`'s basePath change; CI's Lighthouse run on this PR verifies the audit still passes. (Same mechanism, just the correct repo name — Home Performance has been 90–97%, well above the 55% threshold.)

Resolves the `FFC_Single_Page_Template` review threads from #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_