### PR TITLE
feat: add a Fundraising page listing all of the year's fundraisers

### DIFF
--- a/src/app/fundraising/page.tsx
+++ b/src/app/fundraising/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { fundraisers, type Fundraiser } from '@/data/fundraisers'
+
+export const metadata: Metadata = {
+  title: 'Fundraising',
+  description:
+    "Freedom Rising USA's fundraising events and campaigns supporting our mission to celebrate American heritage, honor veterans, and strengthen community in Centre County, PA.",
+  alternates: { canonical: '/fundraising' },
+}
+
+const statusStyles: Record<Fundraiser['status'], { label: string; className: string }> = {
+  active: { label: 'Active', className: 'bg-green-100 text-green-800' },
+  upcoming: { label: 'Upcoming', className: 'bg-blue-100 text-blue-800' },
+  completed: { label: 'Completed', className: 'bg-gray-200 text-gray-700' },
+}
+
+export default function FundraisingPage() {
+  return (
+    <main className="py-[60px]">
+      <div className="w-[90%] mx-auto max-w-[1000px]">
+        <h1 className="text-[40px] lg:text-[48px] text-center mb-4" id="faustina-font">
+          Fundraising
+        </h1>
+        <p
+          className="text-center text-[18px] lg:text-[20px] text-gray-600 max-w-[760px] mx-auto mb-[50px]"
+          id="lato-font"
+        >
+          Every dollar raised supports Freedom Rising USA&apos;s mission to celebrate American
+          heritage, honor veterans, and bring our community together. Here are the fundraising
+          efforts we&apos;ve run this year.
+        </p>
+
+        <div className="space-y-8">
+          {fundraisers.map((f) => {
+            const status = statusStyles[f.status]
+            const isExternal = Boolean(f.link && f.link.startsWith('http'))
+            return (
+              <article
+                key={f.id}
+                className="bg-white rounded-lg shadow-lg p-8 border-2 border-[#BF0A30]"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                  <h2
+                    className="text-[28px] lg:text-[32px] font-[500] text-[#002868]"
+                    id="faustina-font"
+                  >
+                    {f.title}
+                  </h2>
+                  <span
+                    className={`px-3 py-1 rounded-full text-sm font-semibold ${status.className}`}
+                    id="lato-font"
+                  >
+                    {status.label}
+                  </span>
+                </div>
+
+                <p className="text-[18px] text-gray-700 mb-6" id="lato-font">
+                  {f.description}
+                </p>
+
+                <div className="bg-[#002868] text-white rounded-lg p-6 mb-6" id="lato-font">
+                  <div className="flex items-start gap-4 mb-2">
+                    <span className="font-[700] min-w-[90px]">When:</span>
+                    <span>{f.period}</span>
+                  </div>
+                  {f.location && (
+                    <div className="flex items-start gap-4">
+                      <span className="font-[700] min-w-[90px]">Where:</span>
+                      <span>{f.location}</span>
+                    </div>
+                  )}
+                </div>
+
+                {f.details && f.details.length > 0 && (
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-6" id="lato-font">
+                    {f.details.map((d) => (
+                      <div
+                        key={d}
+                        className="bg-gray-50 rounded-lg p-3 text-center text-sm text-gray-700 shadow-sm"
+                      >
+                        {d}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {f.link && f.linkLabel && (
+                  <div className="text-center">
+                    <Link
+                      href={f.link}
+                      target={isExternal ? '_blank' : undefined}
+                      rel={isExternal ? 'noopener noreferrer' : undefined}
+                      className="inline-block bg-[#BF0A30] text-white px-8 py-3 rounded-full text-[18px] font-[500] hover:bg-[#a00828] transition-colors"
+                      id="lato-font"
+                    >
+                      {f.linkLabel}
+                    </Link>
+                  </div>
+                )}
+              </article>
+            )
+          })}
+        </div>
+
+        <div className="text-center mt-[50px]">
+          <Link href="/" className="text-[#002868] underline text-[18px]" id="lato-font">
+            ← Back to Home
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/', changeFrequency: 'weekly', priority: 1 },
     { path: '/parade-brief', changeFrequency: 'monthly', priority: 0.8 },
     { path: '/parade-registration', changeFrequency: 'monthly', priority: 0.8 },
+    { path: '/fundraising', changeFrequency: 'monthly', priority: 0.7 },
     { path: '/cookie-policy', changeFrequency: 'yearly', priority: 0.3 },
     { path: '/donation-policy', changeFrequency: 'yearly', priority: 0.3 },
     { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -63,6 +63,10 @@ const Footer: React.FC = () => {
                 name: 'Parade Brief',
                 href: '/parade-brief',
               },
+              {
+                name: 'Fundraising',
+                href: '/fundraising',
+              },
             ].map((link) => (
               <li key={link.name}>
                 <Link

--- a/src/data/fundraisers.ts
+++ b/src/data/fundraisers.ts
@@ -1,0 +1,43 @@
+import { fishFry } from './fundraising-events'
+
+export type FundraiserStatus = 'active' | 'completed' | 'upcoming'
+
+export type Fundraiser = {
+  id: string
+  title: string
+  status: FundraiserStatus
+  /** Human-readable timeframe, e.g. "Year-round" or "Feb–Apr 2026". */
+  period: string
+  location?: string
+  description: string
+  /** Optional bullet details (e.g. the schedule of a recurring event). */
+  details?: string[]
+  /** Call-to-action link. Omit for completed fundraisers with no live action. */
+  link?: string
+  linkLabel?: string
+}
+
+// All fundraising efforts, newest/active first. Add new fundraisers here.
+export const fundraisers: Fundraiser[] = [
+  {
+    id: 'independence-day-parade',
+    title: 'Independence Day Parade Fund',
+    status: 'active',
+    period: 'Year-round',
+    location: 'State College, PA',
+    description:
+      'Help us produce the annual Central Pennsylvania Independence Day Parade. Donations support marching bands, floats, road permits, insurance, and the volunteers who make the day possible.',
+    link: '/#donate',
+    linkLabel: 'Donate to the Parade',
+  },
+  {
+    id: 'lent-friday-fish-fry',
+    title: fishFry.title,
+    status: 'completed',
+    period: 'Fridays during Lent (Feb 20 – Apr 3, 2026)',
+    location: fishFry.location,
+    description: fishFry.description,
+    details: fishFry.dates.map((d) => `${d.label} · ${d.time}`),
+    // Completed for the year — no live ordering link. The event returns next Lent.
+  },
+]

--- a/src/data/fundraisers.ts
+++ b/src/data/fundraisers.ts
@@ -17,6 +17,17 @@ export type Fundraiser = {
   linkLabel?: string
 }
 
+// Derive the fish-fry timeframe from its schedule so the label can never drift
+// out of sync with fundraising-events.ts (e.g. when next year's dates change).
+const fishFryDates = fishFry.dates
+const stripWeekday = (label: string) => label.replace(/^\w+,\s*/, '')
+const fishFryPeriod =
+  fishFryDates.length > 0
+    ? `Fridays during Lent (${stripWeekday(fishFryDates[0].label)} – ${stripWeekday(
+        fishFryDates[fishFryDates.length - 1].label
+      )})`
+    : 'Fridays during Lent'
+
 // All fundraising efforts, newest/active first. Add new fundraisers here.
 export const fundraisers: Fundraiser[] = [
   {
@@ -34,7 +45,7 @@ export const fundraisers: Fundraiser[] = [
     id: 'lent-friday-fish-fry',
     title: fishFry.title,
     status: 'completed',
-    period: 'Fridays during Lent (Feb 20 – Apr 3, 2026)',
+    period: fishFryPeriod,
     location: fishFry.location,
     description: fishFry.description,
     details: fishFry.dates.map((d) => `${d.label} · ${d.time}`),

--- a/tests/fundraising-page.spec.ts
+++ b/tests/fundraising-page.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Fundraising Page Tests (/fundraising)
+ *
+ * These tests verify that:
+ * 1. The dedicated /fundraising page renders with its heading
+ * 2. Both fundraisers (active parade fund + completed fish fry) are listed
+ * 3. Status badges and the parade donate CTA render correctly
+ * 4. The page is reachable from the footer and links back home
+ * 5. The page renders on a mobile viewport
+ *
+ * NOTE: The local preview server (`serve -s out`) uses SPA fallback, so a hard
+ * navigation to /fundraising returns the homepage shell. To match the suite's
+ * existing convention (and how a visitor actually reaches the page), we navigate
+ * from the homepage and click the footer link for client-side routing.
+ */
+
+async function gotoFundraising(page: Page) {
+  await page.goto('/')
+  // Wait for the app to settle/hydrate so the click triggers client-side routing
+  // rather than a full navigation (which the SPA-fallback preview can't resolve).
+  await page.waitForLoadState('networkidle')
+  // Dismiss the cookie-consent banner so it doesn't intercept the footer link
+  // (it is fixed to the bottom and overlaps the footer on small viewports).
+  const acceptCookies = page.getByRole('button', { name: 'Accept All' })
+  if (await acceptCookies.isVisible().catch(() => false)) {
+    await acceptCookies.click()
+  }
+  const footerLink = page.locator('footer a[href="/fundraising"]').first()
+  await footerLink.scrollIntoViewIfNeeded()
+  await footerLink.click()
+  await expect(page).toHaveURL(/\/fundraising$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'Fundraising' })).toBeVisible()
+}
+
+test.describe('Fundraising Page', () => {
+  test('should render the fundraising page heading', async ({ page }) => {
+    await gotoFundraising(page)
+  })
+
+  test('should list both fundraisers with status badges', async ({ page }) => {
+    await gotoFundraising(page)
+
+    // Active parade fund
+    await expect(page.getByRole('heading', { name: 'Independence Day Parade Fund' })).toBeVisible()
+    await expect(page.getByText('Active', { exact: true })).toBeVisible()
+
+    // Completed fish fry
+    await expect(page.getByRole('heading', { name: 'Lent Friday Fish Fry' })).toBeVisible()
+    await expect(page.getByText('Completed', { exact: true })).toBeVisible()
+  })
+
+  test('should show the donate CTA for the active parade fund', async ({ page }) => {
+    await gotoFundraising(page)
+
+    const donateLink = page.getByRole('link', { name: 'Donate to the Parade' })
+    await expect(donateLink).toBeVisible()
+    await expect(donateLink).toHaveAttribute('href', '/#donate')
+  })
+
+  test('should link back to the homepage', async ({ page }) => {
+    await gotoFundraising(page)
+
+    const backLink = page.getByRole('link', { name: '← Back to Home' })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/')
+  })
+
+  test('should be reachable from the footer', async ({ page }) => {
+    await page.goto('/')
+
+    const footerLink = page.locator('footer a[href="/fundraising"]').first()
+    await expect(footerLink).toBeVisible()
+    await footerLink.click()
+    await expect(page).toHaveURL(/\/fundraising$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Fundraising' })).toBeVisible()
+  })
+
+  test('should render on a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 })
+    await gotoFundraising(page)
+
+    await expect(page.getByRole('heading', { name: 'Independence Day Parade Fund' })).toBeVisible()
+  })
+})

--- a/tests/fundraising-page.spec.ts
+++ b/tests/fundraising-page.spec.ts
@@ -68,13 +68,10 @@ test.describe('Fundraising Page', () => {
   })
 
   test('should be reachable from the footer', async ({ page }) => {
-    await page.goto('/')
-
-    const footerLink = page.locator('footer a[href="/fundraising"]').first()
-    await expect(footerLink).toBeVisible()
-    await footerLink.click()
-    await expect(page).toHaveURL(/\/fundraising$/)
-    await expect(page.getByRole('heading', { level: 1, name: 'Fundraising' })).toBeVisible()
+    // gotoFundraising navigates via the footer link (dismissing the cookie
+    // banner first), so it doubles as the footer-reachability check and keeps
+    // navigation consistent with the other tests.
+    await gotoFundraising(page)
   })
 
   test('should render on a mobile viewport', async ({ page }) => {

--- a/tests/fundraising-page.spec.ts
+++ b/tests/fundraising-page.spec.ts
@@ -18,15 +18,16 @@ import { test, expect, type Page } from '@playwright/test'
 
 async function gotoFundraising(page: Page) {
   await page.goto('/')
-  // Wait for the app to settle/hydrate so the click triggers client-side routing
-  // rather than a full navigation (which the SPA-fallback preview can't resolve).
-  await page.waitForLoadState('networkidle')
-  // Dismiss the cookie-consent banner so it doesn't intercept the footer link
-  // (it is fixed to the bottom and overlaps the footer on small viewports).
-  const acceptCookies = page.getByRole('button', { name: 'Accept All' })
-  if (await acceptCookies.isVisible().catch(() => false)) {
-    await acceptCookies.click()
-  }
+  // Dismiss the cookie-consent banner if it appears. It is fixed to the bottom
+  // and can overlap/intercept the footer link, especially on small viewports.
+  // Waiting for the button to be clickable also confirms the app has hydrated,
+  // so the footer click does client-side routing (which the SPA-fallback preview
+  // needs) rather than a full navigation. We avoid `networkidle`, which never
+  // settles in CI because of long-lived analytics requests.
+  await page
+    .getByRole('button', { name: 'Accept All' })
+    .click({ timeout: 15000 })
+    .catch(() => {})
   const footerLink = page.locator('footer a[href="/fundraising"]').first()
   await footerLink.scrollIntoViewIfNeeded()
   await footerLink.click()


### PR DESCRIPTION
## Summary

Adds a dedicated **`/fundraising`** page that gathers every fundraising effort in one place, so visitors can see what's running now and what has wrapped for the year — as requested ("a fundraising page that contains all the fundraisers done over the year").

Scope is the two fundraisers found in the codebase:

- **Independence Day Parade Fund** — `Active` badge, links to the on-page donation form (`/#donate`).
- **Lent Friday Fish Fry** — `Completed` badge, preserved with its full Lent schedule; the event returns next Lent, so there's no live ordering link for now.

## How it works

- Data-driven via `src/data/fundraisers.ts` (status: `active` / `upcoming` / `completed`), so adding next year's efforts is a one-line change. The fish fry pulls its title/location/dates from the existing `fundraising-events.ts`, so it stays in sync.
- Status badges (green / blue / gray), When/Where box, schedule grid, and a CTA button for any fundraiser with a live link.
- Linked from the footer **Quick Links** and added to `sitemap.ts`.

## Verification

- `npm run format` clean · `npm run lint` 0 errors (2 pre-existing `<img>` warnings) · `npm test` 25 passed · `npm run build` OK (`/fundraising` route emitted).
- New `tests/fundraising-page.spec.ts` — **6 passed**: heading, both fundraisers + badges, donate CTA, back-home link, footer navigation, mobile viewport.
- The seasonal fish-fry removal guard on the homepage is unaffected (it checks `/`, and the fish fry now appears only on `/fundraising`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_