### PR TITLE
fix(a11y): heading order, label-in-name, and tap-target fixes (pages to 100)

### DIFF
--- a/src/app/parade-brief/page.tsx
+++ b/src/app/parade-brief/page.tsx
@@ -293,7 +293,7 @@ export default function ParadeBrief() {
               <span className="hidden sm:inline">Previous</span>
             </button>
 
-            <div className="flex gap-2 items-center">
+            <div className="flex gap-1 items-center">
               <span className="text-gray-600 mr-2">
                 {currentSlide + 1} / {slides.length}
               </span>
@@ -301,11 +301,17 @@ export default function ParadeBrief() {
                 <button
                   key={index}
                   onClick={() => goToSlide(index)}
-                  className={`w-3 h-3 rounded-full transition-colors ${
-                    index === currentSlide ? 'bg-[#002868]' : 'bg-gray-300 hover:bg-gray-400'
-                  }`}
+                  className="group flex h-7 w-7 items-center justify-center rounded-full"
                   aria-label={`Go to slide ${index + 1}`}
-                />
+                >
+                  <span
+                    className={`block h-3 w-3 rounded-full transition-colors ${
+                      index === currentSlide
+                        ? 'bg-[#002868]'
+                        : 'bg-gray-300 group-hover:bg-gray-400'
+                    }`}
+                  />
+                </button>
               ))}
             </div>
 

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -168,7 +168,7 @@ const Footer: React.FC = () => {
               href="https://www.google.com/maps/search/?api=1&query=1950+Pine+Hall+Rd+Suite+90+State+College+PA+16801"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Open address in Google Maps"
+              aria-label="Address: 1950 Pine Hall Rd Suite 90, State College, PA 16801, open in Google Maps"
               className="flex items-start gap-3 hover:opacity-80 transition-opacity"
             >
               <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />

--- a/src/components/ui/SustainableFundingCard.tsx
+++ b/src/components/ui/SustainableFundingCard.tsx
@@ -23,12 +23,12 @@ export const SustainableFundingCard: React.FC<SustainableFundingCardProps> = ({
 
       {/* Content Section */}
       <div className="p-4 text-center">
-        <h3
+        <h2
           className="text-[24px] lg:text-[28px] font-[400] text-[#000000] leading-[100%] mb-3"
           id="lato-font"
         >
           {title}
-        </h3>
+        </h2>
         <p
           className="text-[16px] sm:text-[18px] font-[400] text-[#000000] leading-[140%]"
           id="lato-font"

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -33,9 +33,9 @@ export default function TeamMemberCard({
 
         {/* Text Content */}
         <div className="text-center space-y-2">
-          <h3 className="text-[32px] font-[400]" id="lato-font">
+          <h2 className="text-[32px] font-[400]" id="lato-font">
             {name}
-          </h3>
+          </h2>
           <p className="text-[25px] font-[400]" id="lato-font">
             {title}
           </p>


### PR DESCRIPTION
## Summary

A pre-event accessibility pass. Lighthouse flagged three real issues; fixing them takes **Home, Fundraising, Parade Registration, and Parade Brief to 100** accessibility (were 94–96 in production CI).

| Fix | Audit | Where |
|-----|-------|-------|
| Card titles `<h3>` → `<h2>` (sat directly under section `<h1>`, skipping a level) | `heading-order` | `SustainableFundingCard`, `TeamMemberCard` |
| Address link `aria-label` now includes the visible address text | `label-content-name-mismatch` (WCAG 2.5.3 Label in Name) | footer |
| Slide pagination dots wrapped in a 28px button hit-area (dot stays 12px) | `target-size` (WCAG 2.5.8) | Parade Brief |

No visual change — the heading fonts are set by classes, not the tag; the dots look identical, just with a larger tap area.

## Verification

- Local Lighthouse (accessibility): **Home 100, Fundraising 100, Parade Registration 100, Parade Brief 100** (Home was 94, Parade Brief 96 before).
- `npm run format` clean · `npm run lint` 0 errors (2 pre-existing `<img>` warnings) · `npm test` 25 passed · `npm run build` OK.
- No E2E asserts on the changed elements (the parade-brief `level: 2` check targets slide content, untouched).

## Context / notes from the same pass

- **Best Practices (Home 68%)** was investigated and intentionally left as-is: it's driven by third-party cookies from Google Tag Manager, the Meta Pixel, and the Zeffy donation embed — all intentional/essential and clearing the 65% gate. Not worth chasing by removing tracking or the donate form.
- **Pre-event QA**: donation embed (Zeffy) and registration (Google Form, HTTP 200) are correctly wired; parade pages render correctly. One content note for maintainers — the parade-registration "guaranteed spot" deadline (June 22, 2026) has now passed; the page still accepts late registrations per its own text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe86G2NhufUZJpWEUk8Pd)_