### PR TITLE
feat: add In the News media coverage page

### DIFF
--- a/__tests__/data/press-coverage.test.ts
+++ b/__tests__/data/press-coverage.test.ts
@@ -1,5 +1,31 @@
 import { pressArticles } from '../../src/data/press-coverage'
 
+// Deterministic parser for the fixed "Month D, YYYY" display format —
+// `new Date(string)` on non-ISO input is implementation-dependent and
+// could make the ordering assertion flaky across runtimes.
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+function parseDisplayDate(date: string): number | null {
+  const match = /^([A-Za-z]+) (\d{1,2}), (\d{4})$/.exec(date)
+  if (!match) return null
+  const monthIndex = MONTHS.indexOf(match[1])
+  if (monthIndex === -1) return null
+  return Date.UTC(Number(match[3]), monthIndex, Number(match[2]))
+}
+
 describe('press coverage data', () => {
   it('has at least one article', () => {
     expect(pressArticles.length).toBeGreaterThan(0)
@@ -25,13 +51,13 @@ describe('press coverage data', () => {
     }
   })
 
-  it('has parseable dates ordered newest first', () => {
-    const times = pressArticles.map((a) => new Date(a.date).getTime())
+  it('has "Month D, YYYY" dates ordered newest first', () => {
+    const times = pressArticles.map((a) => parseDisplayDate(a.date))
     for (const time of times) {
-      expect(Number.isNaN(time)).toBe(false)
+      expect(time).not.toBeNull()
     }
     for (let i = 1; i < times.length; i++) {
-      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i])
+      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i]!)
     }
   })
 })

--- a/__tests__/data/press-coverage.test.ts
+++ b/__tests__/data/press-coverage.test.ts
@@ -1,0 +1,37 @@
+import { pressArticles } from '../../src/data/press-coverage'
+
+describe('press coverage data', () => {
+  it('has at least one article', () => {
+    expect(pressArticles.length).toBeGreaterThan(0)
+  })
+
+  it('has unique ids', () => {
+    const ids = pressArticles.map((a) => a.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('has non-empty required fields on every article', () => {
+    for (const article of pressArticles) {
+      expect(article.headline.trim()).not.toBe('')
+      expect(article.outlet.trim()).not.toBe('')
+      expect(article.date.trim()).not.toBe('')
+      expect(article.excerpt.trim()).not.toBe('')
+    }
+  })
+
+  it('links every article to an external https URL', () => {
+    for (const article of pressArticles) {
+      expect(article.url).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('has parseable dates ordered newest first', () => {
+    const times = pressArticles.map((a) => new Date(a.date).getTime())
+    for (const time of times) {
+      expect(Number.isNaN(time)).toBe(false)
+    }
+    for (let i = 1; i < times.length; i++) {
+      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i])
+    }
+  })
+})

--- a/src/app/in-the-news/page.tsx
+++ b/src/app/in-the-news/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { pressArticles } from '@/data/press-coverage'
+
+export const metadata: Metadata = {
+  title: 'In the News',
+  description:
+    'Media coverage of Freedom Rising USA and our events, including the annual Central Pennsylvania Independence Day Parade in State College, PA.',
+  alternates: { canonical: '/in-the-news' },
+}
+
+export default function InTheNewsPage() {
+  return (
+    <main className="py-[60px]">
+      <div className="w-[90%] mx-auto max-w-[1000px]">
+        <h1 className="text-[40px] lg:text-[48px] text-center mb-4" id="faustina-font">
+          In the News
+        </h1>
+        <p
+          className="text-center text-[18px] lg:text-[20px] text-gray-600 max-w-[760px] mx-auto mb-[50px]"
+          id="lato-font"
+        >
+          Press coverage of Freedom Rising USA and our events, from the founding of our nonprofit to
+          the annual Central Pennsylvania Independence Day Parade. Each headline links to the full
+          story on the outlet&apos;s website.
+        </p>
+
+        <div className="space-y-8">
+          {pressArticles.map((article) => (
+            <article
+              key={article.id}
+              className="bg-white rounded-lg shadow-lg p-8 border-2 border-[#002868]"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                <span
+                  className="px-3 py-1 rounded-full text-sm font-semibold bg-blue-100 text-blue-800"
+                  id="lato-font"
+                >
+                  {article.outlet}
+                </span>
+                <span className="text-sm text-gray-600" id="lato-font">
+                  {article.date}
+                  {article.author && ` · By ${article.author}`}
+                </span>
+              </div>
+
+              <h2
+                className="text-[24px] lg:text-[28px] font-[500] text-[#002868] mb-4"
+                id="faustina-font"
+              >
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-[#BF0A30] transition-colors"
+                >
+                  {article.headline}
+                </a>
+              </h2>
+
+              <p className="text-[18px] text-gray-700 mb-6" id="lato-font">
+                {article.excerpt}
+              </p>
+
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-[#BF0A30] text-white px-8 py-3 rounded-full text-[18px] font-[500] hover:bg-[#a00828] transition-colors"
+                id="lato-font"
+              >
+                Read on {article.outlet}
+              </a>
+            </article>
+          ))}
+        </div>
+
+        <div className="text-center mt-[50px]">
+          <Link href="/" className="text-[#002868] underline text-[18px]" id="lato-font">
+            ← Back to Home
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,6 +18,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/parade-brief', changeFrequency: 'monthly', priority: 0.8 },
     { path: '/parade-registration', changeFrequency: 'monthly', priority: 0.8 },
     { path: '/fundraising', changeFrequency: 'monthly', priority: 0.7 },
+    { path: '/in-the-news', changeFrequency: 'monthly', priority: 0.7 },
     { path: '/cookie-policy', changeFrequency: 'yearly', priority: 0.3 },
     { path: '/donation-policy', changeFrequency: 'yearly', priority: 0.3 },
     { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -67,6 +67,10 @@ const Footer: React.FC = () => {
                 name: 'Fundraising',
                 href: '/fundraising',
               },
+              {
+                name: 'In the News',
+                href: '/in-the-news',
+              },
             ].map((link) => (
               <li key={link.name}>
                 <Link

--- a/src/data/press-coverage.ts
+++ b/src/data/press-coverage.ts
@@ -1,0 +1,66 @@
+export type PressArticle = {
+  id: string
+  headline: string
+  outlet: string
+  /** Human-readable publication date, e.g. "July 4, 2026". */
+  date: string
+  author?: string
+  /** Short summary in our own words — never republish article text (copyright). */
+  excerpt: string
+  url: string
+}
+
+// Press coverage of Freedom Rising USA and its events, newest first.
+// Add new articles at the top. Link and summarize only — do not copy
+// article text or photos.
+export const pressArticles: PressArticle[] = [
+  {
+    id: 'statecollege-parade-250th',
+    headline: "Independence Day Parade in State College Celebrates America's 250th",
+    outlet: 'StateCollege.com',
+    date: 'July 4, 2026',
+    excerpt:
+      "Coverage of the 99th annual parade on America's 250th birthday — the first run by Freedom Rising USA — with about four dozen organizations marching along College Avenue and Commander D.J. Watkins on the group's nonpartisan mission.",
+    url: 'https://www.statecollege.com/articles/community/independence-day-parade-in-state-college-celebrates-americas-250th/',
+  },
+  {
+    id: 'statecollege-parade-rolls-on',
+    headline: "New Organization Ensures State College's July 4 Parade Rolls On",
+    outlet: 'StateCollege.com',
+    date: 'July 1, 2026',
+    author: 'Geoff Rushton',
+    excerpt:
+      'A feature on the founding of Freedom Rising USA — formed out of Nittany American Legion Post 245 and led by President D.J. Watkins and Vice President Mitch DeLong — and how the new 501(c)(3) kept the 99th annual parade on the calendar.',
+    url: 'https://www.statecollege.com/articles/community/new-organization-ensures-state-colleges-july-4-parade-rolls-on/',
+  },
+  {
+    id: 'statecollege-july4-guide',
+    headline: 'What to Know About Fourth of July Celebrations Around Centre County',
+    outlet: 'StateCollege.com',
+    date: 'June 29, 2026',
+    author: 'Geoff Rushton',
+    excerpt:
+      "Centre County's July 4 event guide, naming Freedom Rising USA as the nonpartisan nonprofit sponsoring and organizing the State College parade, with the route and step-off details.",
+    url: 'https://www.statecollege.com/articles/community/what-to-know-about-fourth-of-july-celebrations-around-centre-county/',
+  },
+  {
+    id: 'wjac-tourism-funds',
+    headline: 'Centre County Tourism Funds Help State College Fourth of July Parade Move Forward',
+    outlet: 'WJAC-TV',
+    date: 'June 24, 2026',
+    author: 'Gary Sinderson',
+    excerpt:
+      'TV news coverage of Freedom Rising USA receiving a Centre County tourism grant to help cover parade costs, keeping the Fourth of July parade on track after funding became an issue.',
+    url: 'https://wjactv.com/news/local/centre-county-tourism-funds-help-state-college-fourth-of-july-parade-move-forward',
+  },
+  {
+    id: 'statecollege-tourism-grants',
+    headline: 'Centre County Tourism Grant Program Awards Record $1.15M',
+    outlet: 'StateCollege.com',
+    date: 'June 24, 2026',
+    author: 'Geoff Rushton',
+    excerpt:
+      "Reporting on the county's record tourism grant awards, quoting Vice President Mitch DeLong on Freedom Rising USA stepping forward to organize the parade and its vision for the parade's approaching centennial.",
+    url: 'https://www.statecollege.com/articles/community/centre-county-tourism-grant-program-awards-record-1-15m/',
+  },
+]

--- a/tests/in-the-news.spec.ts
+++ b/tests/in-the-news.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, type Page } from '@playwright/test'
+import { pressArticles } from '../src/data/press-coverage'
+
+/**
+ * In the News Page Tests (/in-the-news)
+ *
+ * These tests verify that:
+ * 1. The dedicated /in-the-news page renders with its heading
+ * 2. Every press article from src/data/press-coverage.ts is listed
+ * 3. Article links open the original story in a new tab
+ * 4. The page is reachable from the footer and links back home
+ * 5. The page renders on a mobile viewport
+ *
+ * NOTE: The local preview server (`serve -s out`) uses SPA fallback, so a hard
+ * navigation to /in-the-news returns the homepage shell. To match the suite's
+ * existing convention (and how a visitor actually reaches the page), we navigate
+ * from the homepage and click the footer link for client-side routing.
+ */
+
+async function gotoInTheNews(page: Page) {
+  await page.goto('/')
+  // Dismiss the cookie-consent banner if it appears. It is fixed to the bottom
+  // and can overlap/intercept the footer link, especially on small viewports.
+  // Waiting for the button to be clickable also confirms the app has hydrated,
+  // so the footer click does client-side routing (which the SPA-fallback preview
+  // needs) rather than a full navigation. We avoid `networkidle`, which never
+  // settles in CI because of long-lived analytics requests.
+  await page
+    .getByRole('button', { name: 'Accept All' })
+    .click({ timeout: 15000 })
+    .catch(() => {})
+  const footerLink = page.locator('footer a[href="/in-the-news"]').first()
+  await footerLink.scrollIntoViewIfNeeded()
+  await footerLink.click()
+  await expect(page).toHaveURL(/\/in-the-news$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'In the News' })).toBeVisible()
+}
+
+test.describe('In the News Page', () => {
+  test('should render the in-the-news page heading', async ({ page }) => {
+    await gotoInTheNews(page)
+  })
+
+  test('should list every press article', async ({ page }) => {
+    await gotoInTheNews(page)
+
+    for (const article of pressArticles) {
+      await expect(page.getByRole('heading', { name: article.headline })).toBeVisible()
+    }
+  })
+
+  test('should link each article to the original story in a new tab', async ({ page }) => {
+    await gotoInTheNews(page)
+
+    for (const article of pressArticles) {
+      const link = page.getByRole('link', { name: article.headline })
+      await expect(link).toHaveAttribute('href', article.url)
+      await expect(link).toHaveAttribute('target', '_blank')
+      await expect(link).toHaveAttribute('rel', /noopener/)
+    }
+  })
+
+  test('should link back to the homepage', async ({ page }) => {
+    await gotoInTheNews(page)
+
+    const backLink = page.getByRole('link', { name: '← Back to Home' })
+    await expect(backLink).toBeVisible()
+    await expect(backLink).toHaveAttribute('href', '/')
+  })
+
+  test('should be reachable from the footer', async ({ page }) => {
+    // gotoInTheNews navigates via the footer link (dismissing the cookie
+    // banner first), so it doubles as the footer-reachability check and keeps
+    // navigation consistent with the other tests.
+    await gotoInTheNews(page)
+  })
+
+  test('should render on a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 })
+    await gotoInTheNews(page)
+
+    await expect(page.getByRole('heading', { name: pressArticles[0].headline })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Description

Adds a dedicated `/in-the-news` page showcasing verified press coverage of Freedom Rising USA and the Central Pennsylvania Independence Day Parade. The page is data-driven (articles live in `src/data/press-coverage.ts`) so future coverage can be added with a single data entry. Articles are linked and summarized in our own words only — no article text or photos are republished (copyright).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update
- [ ] CI/CD or tooling change

## Related Issue(s)

Fixes #148

## Changes Made

- Add `src/data/press-coverage.ts` with five confirmed articles (StateCollege.com and WJAC-TV), newest first, with a typed `PressArticle` shape
- Add `src/app/in-the-news/page.tsx` following the fundraising page's layout conventions (kebab-case route, `faustina-font`/`lato-font` styling, back-to-home link)
- Add an "In the News" quick link to the footer
- Add `/in-the-news` to `sitemap.ts`
- Add `__tests__/data/press-coverage.test.ts` (unique ids, required fields, https links, newest-first ordering)
- Add `tests/in-the-news.spec.ts` Playwright suite following the existing footer-navigation convention (heading, every article listed, external links open in new tab with `noopener`, back link, footer reachability, mobile viewport)

## Screenshots (if applicable)

N/A — layout mirrors the existing `/fundraising` page (card list with outlet badge, date/byline, excerpt, and external CTA button).

## Testing Performed

### Manual Testing

- [x] Tested on desktop browsers (Chrome, Firefox, Safari, Edge) — verified via Playwright Chromium; layout reuses existing responsive patterns
- [x] Tested on mobile devices/responsive views — mobile-viewport E2E test included
- [x] Verified all interactive elements work correctly
- [x] Checked console for errors

### Automated Testing

- [x] `npm run lint` - All linting checks pass (only pre-existing warnings in untouched files)
- [x] `npm test` - All unit tests pass (30/30, including 5 new)
- [x] `npm run build` - Build completes successfully (`/in-the-news` prerendered in static export)
- [x] `npm run test:e2e` - All E2E tests pass (61 passed, 26 skipped, including 6 new)

### Accessibility

- [x] Keyboard navigation works correctly — standard links/landmarks only
- [x] Color contrast meets WCAG standards — reuses the site's existing palette (#002868/#BF0A30 on white)
- [x] Screen reader compatibility verified (if applicable) — semantic `article`/heading structure, descriptive link text

## Documentation

- [x] Code is self-documenting or includes comments where needed
- [ ] README.md updated (if needed) — N/A
- [ ] Other documentation updated (if needed) — N/A

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] My commits follow the conventional commit format
- [x] I have rebased my branch on the latest main

## Additional Notes

All five articles were verified against the live sources before inclusion (see #148 for the confirmation list). Two brief grant-listing mentions (The Express, WTAJ) were intentionally excluded as too minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Xg1E1XP1cboF5NQugxQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6Xg1E1XP1cboF5NQugxQF)_