### PR TITLE
feat: surface press coverage in nav, home page, and post-parade banner

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -42,6 +42,12 @@ describe('Header component', () => {
     expect(screen.getByText('Home')).toBeInTheDocument()
   })
 
+  it('should display a News link to the in-the-news page', () => {
+    render(<Header />)
+    const newsLink = screen.getByText('News').closest('a')
+    expect(newsLink).toHaveAttribute('href', '/in-the-news')
+  })
+
   it('should have navigation links', () => {
     render(<Header />)
     // Check that navigation has at least some links

--- a/__tests__/lib/parade.test.ts
+++ b/__tests__/lib/parade.test.ts
@@ -1,0 +1,35 @@
+import { nextIndependenceDay } from '../../src/lib/parade'
+
+describe('nextIndependenceDay', () => {
+  it('counts down to July 4 of the current year before the holiday', () => {
+    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 5, 24))) // June 24, 2026
+    expect(timing.days).toBe(10)
+    expect(timing.isToday).toBe(false)
+    expect(timing.dateLabel).toContain('July 4, 2026')
+    expect(timing.previousYear).toBe(2025)
+    expect(timing.daysSincePrevious).toBe(355)
+  })
+
+  it('reports the parade day itself as today', () => {
+    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 4))) // July 4, 2026
+    expect(timing.days).toBe(0)
+    expect(timing.isToday).toBe(true)
+    expect(timing.previousYear).toBe(2026)
+    expect(timing.daysSincePrevious).toBe(0)
+  })
+
+  it('rolls over to next year after the holiday and tracks days since', () => {
+    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 5))) // July 5, 2026
+    expect(timing.days).toBe(364)
+    expect(timing.isToday).toBe(false)
+    expect(timing.dateLabel).toContain('July 4, 2027')
+    expect(timing.previousYear).toBe(2026)
+    expect(timing.daysSincePrevious).toBe(1)
+  })
+
+  it('keeps counting days since the previous parade later in the month', () => {
+    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 18))) // July 18, 2026
+    expect(timing.previousYear).toBe(2026)
+    expect(timing.daysSincePrevious).toBe(14)
+  })
+})

--- a/__tests__/lib/parade.test.ts
+++ b/__tests__/lib/parade.test.ts
@@ -2,7 +2,7 @@ import { nextIndependenceDay } from '../../src/lib/parade'
 
 describe('nextIndependenceDay', () => {
   it('counts down to July 4 of the current year before the holiday', () => {
-    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 5, 24))) // June 24, 2026
+    const timing = nextIndependenceDay(new Date(2026, 5, 24)) // June 24, 2026
     expect(timing.days).toBe(10)
     expect(timing.isToday).toBe(false)
     expect(timing.dateLabel).toContain('July 4, 2026')
@@ -11,7 +11,7 @@ describe('nextIndependenceDay', () => {
   })
 
   it('reports the parade day itself as today', () => {
-    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 4))) // July 4, 2026
+    const timing = nextIndependenceDay(new Date(2026, 6, 4)) // July 4, 2026
     expect(timing.days).toBe(0)
     expect(timing.isToday).toBe(true)
     expect(timing.previousYear).toBe(2026)
@@ -19,7 +19,7 @@ describe('nextIndependenceDay', () => {
   })
 
   it('rolls over to next year after the holiday and tracks days since', () => {
-    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 5))) // July 5, 2026
+    const timing = nextIndependenceDay(new Date(2026, 6, 5)) // July 5, 2026
     expect(timing.days).toBe(364)
     expect(timing.isToday).toBe(false)
     expect(timing.dateLabel).toContain('July 4, 2027')
@@ -28,7 +28,7 @@ describe('nextIndependenceDay', () => {
   })
 
   it('keeps counting days since the previous parade later in the month', () => {
-    const timing = nextIndependenceDay(new Date(Date.UTC(2026, 6, 18))) // July 18, 2026
+    const timing = nextIndependenceDay(new Date(2026, 6, 18)) // July 18, 2026
     expect(timing.previousYear).toBe(2026)
     expect(timing.daysSincePrevious).toBe(14)
   })

--- a/src/app/home-page/index.tsx
+++ b/src/app/home-page/index.tsx
@@ -9,6 +9,7 @@ import Results2023 from '@/components/home-page/Results-2023'
 import TheFreeForCharityTeam from '@/components/home-page/TheFreeForCharityTeam'
 import FrequentlyAskedQuestions from '@/components/home-page/FrequentlyAskedQuestions'
 import Events from '@/components/home-page/Events'
+import InTheNews from '@/components/home-page/In-The-News'
 // Seasonal fundraiser (Lent Friday Fish Fry) — finished for the year.
 // Component and data (src/data/fundraising-events.ts) are kept; re-enable next Lent season.
 // import FundraisingEvents from '@/components/home-page/Fundraising-Events'
@@ -19,6 +20,8 @@ const index = () => {
       <Hero />
       {/* 4th of July parade — featured as the current site highlight before the event */}
       <Events />
+      {/* Latest press coverage teaser — full list lives at /in-the-news */}
+      <InTheNews />
       <Mission />
       <Results2023 />
       <VolunteerwithUs />

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { FiMenu } from 'react-icons/fi'
 import { LiaSearchSolid } from 'react-icons/lia'
 import { RxCross2 } from 'react-icons/rx'
@@ -16,6 +17,7 @@ interface MenuItem {
 const SCROLL_OFFSET = 100
 
 const Header: React.FC = () => {
+  const pathname = usePathname()
   const [isScrolled, setIsScrolled] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -27,6 +29,7 @@ const Header: React.FC = () => {
       { label: 'Mission', path: '/#mission' },
       { label: 'Programs', path: '/#programs' },
       { label: 'Events', path: '/#events' },
+      { label: 'News', path: '/in-the-news' },
       { label: 'Volunteer', path: '/#volunteer' },
       { label: 'Donate', path: '/#donate' },
       { label: 'FAQ', path: '/#faq' },
@@ -37,7 +40,10 @@ const Header: React.FC = () => {
 
   const sections = useMemo(
     () =>
-      menuItems.map((item) => item.path.replace('/#', '')).filter((section) => section !== 'hero'),
+      menuItems
+        .filter((item) => item.path.startsWith('/#'))
+        .map((item) => item.path.replace('/#', ''))
+        .filter((section) => section !== 'hero'),
     [menuItems]
   )
 
@@ -79,8 +85,10 @@ const Header: React.FC = () => {
   }
 
   const isActive = (path: string) => {
+    // Page links (no anchor) are active when we're on that page.
+    if (!path.startsWith('/#')) return pathname === path
     const sectionId = path.replace('/#', '')
-    if (sectionId === 'hero') return activeSection === ''
+    if (sectionId === 'hero') return pathname === '/' && activeSection === ''
     return activeSection === sectionId
   }
 

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -87,8 +87,11 @@ const Header: React.FC = () => {
   const isActive = (path: string) => {
     // Page links (no anchor) are active when we're on that page.
     if (!path.startsWith('/#')) return pathname === path
+    // Anchor links only reflect scroll position on the home page; activeSection
+    // is otherwise stale after a client-side route change.
+    if (pathname !== '/') return false
     const sectionId = path.replace('/#', '')
-    if (sectionId === 'hero') return pathname === '/' && activeSection === ''
+    if (sectionId === 'hero') return activeSection === ''
     return activeSection === sectionId
   }
 

--- a/src/components/home-page/In-The-News/index.tsx
+++ b/src/components/home-page/In-The-News/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import Link from 'next/link'
+import { pressArticles } from '@/data/press-coverage'
+
+const FEATURED_COUNT = 3
+
+const InTheNews = () => {
+  const latest = pressArticles.slice(0, FEATURED_COUNT)
+
+  return (
+    <div id="news" className="py-[52px]">
+      <div className="w-[90%] mx-auto max-w-[1280px]">
+        <h1
+          className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-6"
+          id="faustina-font"
+        >
+          In the News
+        </h1>
+        <p
+          className="text-center text-[18px] lg:text-[20px] max-w-[760px] mx-auto mb-[50px]"
+          id="lato-font"
+        >
+          Local media are talking about Freedom Rising USA and the Central Pennsylvania Independence
+          Day Parade. Here&apos;s the latest coverage.
+        </p>
+
+        <div className="grid md:grid-cols-3 gap-6 mb-8">
+          {latest.map((article) => (
+            <article
+              key={article.id}
+              className="bg-white border-2 border-[#002868] rounded-lg p-6 flex flex-col"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                <span
+                  className="px-3 py-1 rounded-full text-sm font-semibold bg-blue-100 text-blue-800"
+                  id="lato-font"
+                >
+                  {article.outlet}
+                </span>
+                <span className="text-sm text-gray-600" id="lato-font">
+                  {article.date}
+                </span>
+              </div>
+              <h2 className="text-[22px] font-[500] text-[#002868] grow" id="faustina-font">
+                <a
+                  href={article.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-[#BF0A30] transition-colors"
+                >
+                  {article.headline}
+                </a>
+              </h2>
+            </article>
+          ))}
+        </div>
+
+        <div className="text-center">
+          <Link
+            href="/in-the-news"
+            className="inline-block bg-[#BF0A30] text-white px-8 py-3 rounded-full text-[18px] font-[500] hover:bg-[#a00828] transition-colors"
+            id="lato-font"
+          >
+            See All Press Coverage
+          </Link>
+        </div>
+      </div>
+
+      <div className="w-[95%] mt-[50px] mx-auto border border-[#2B627B]"></div>
+    </div>
+  )
+}
+
+export default InTheNews

--- a/src/components/ui/ParadeCountdown.tsx
+++ b/src/components/ui/ParadeCountdown.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { nextIndependenceDay, type ParadeTiming } from '@/lib/parade'
+
+// For this many days after July 4, celebrate the parade that just happened
+// (with a link to press coverage) instead of counting down to next year.
+export const POST_PARADE_WINDOW_DAYS = 14
 
 export default function ParadeCountdown() {
   const [timing, setTiming] = useState<ParadeTiming | null>(null)
@@ -15,6 +20,11 @@ export default function ParadeCountdown() {
   // Render nothing until mounted (prevents server/client hydration mismatch).
   if (!timing) return null
 
+  const justHappened =
+    !timing.isToday &&
+    timing.daysSincePrevious >= 1 &&
+    timing.daysSincePrevious <= POST_PARADE_WINDOW_DAYS
+
   return (
     <div
       className="max-w-[800px] mx-auto mb-8 rounded-lg bg-[#BF0A30] text-white text-center px-6 py-4"
@@ -24,6 +34,14 @@ export default function ParadeCountdown() {
       {timing.isToday ? (
         <p className="text-[20px] lg:text-[24px] font-[600]">
           🎆 The parade is today — Happy Independence Day! 🇺🇸
+        </p>
+      ) : justHappened ? (
+        <p className="text-[20px] lg:text-[24px] font-[600]">
+          🎆 Thank you for celebrating with us — the {timing.previousYear} parade{' '}
+          <Link href="/in-the-news" className="underline hover:text-[#F5C045] transition-colors">
+            made the news
+          </Link>
+          !
         </p>
       ) : (
         <p className="text-[20px] lg:text-[24px] font-[600]">

--- a/src/lib/parade.ts
+++ b/src/lib/parade.ts
@@ -4,6 +4,10 @@ export type ParadeTiming = {
   isToday: boolean
   /** Full date label for the next July 4, e.g. "Saturday, July 4, 2026". */
   dateLabel: string
+  /** Whole days since the most recent July 4 (0 on the day itself). */
+  daysSincePrevious: number
+  /** Year of the most recent July 4 on or before today. */
+  previousYear: number
 }
 
 /**
@@ -30,5 +34,10 @@ export function nextIndependenceDay(now: Date = new Date()): ParadeTiming {
     year: 'numeric',
     timeZone: 'UTC',
   })
-  return { days, isToday: days === 0, dateLabel }
+  // On July 4 itself the "most recent" July 4 is today; otherwise it is the
+  // year before the upcoming one.
+  const previousYear = days === 0 ? year : year - 1
+  const previousUTC = Date.UTC(previousYear, 6, 4)
+  const daysSincePrevious = Math.round((todayUTC - previousUTC) / 86_400_000)
+  return { days, isToday: days === 0, dateLabel, daysSincePrevious, previousYear }
 }

--- a/tests/in-the-news.spec.ts
+++ b/tests/in-the-news.spec.ts
@@ -81,4 +81,61 @@ test.describe('In the News Page', () => {
 
     await expect(page.getByRole('heading', { name: pressArticles[0].headline })).toBeVisible()
   })
+
+  test('should be reachable from the desktop header navigation', async ({ page }) => {
+    await page.goto('/')
+    await page
+      .getByRole('button', { name: 'Accept All' })
+      .click({ timeout: 15000 })
+      .catch(() => {})
+
+    const navLink = page.locator('header nav a[href="/in-the-news"]').first()
+    await expect(navLink).toBeVisible()
+    await navLink.click()
+    await expect(page).toHaveURL(/\/in-the-news$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'In the News' })).toBeVisible()
+  })
+
+  test('should be reachable from the mobile header menu', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 })
+    await page.goto('/')
+    await page
+      .getByRole('button', { name: 'Accept All' })
+      .click({ timeout: 15000 })
+      .catch(() => {})
+
+    await page.getByRole('button', { name: 'Open menu' }).click()
+    // The desktop nav renders the same link but is display-hidden on mobile,
+    // so filter to the visible one inside the opened mobile menu.
+    const mobileNavLink = page.locator('header a[href="/in-the-news"]:visible').first()
+    await expect(mobileNavLink).toBeVisible()
+    await mobileNavLink.click()
+    await expect(page).toHaveURL(/\/in-the-news$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'In the News' })).toBeVisible()
+  })
+})
+
+test.describe('Home Page News Teaser', () => {
+  test('should show the latest press headlines with a link to full coverage', async ({ page }) => {
+    await page.goto('/')
+    await page
+      .getByRole('button', { name: 'Accept All' })
+      .click({ timeout: 15000 })
+      .catch(() => {})
+
+    const newsSection = page.locator('#news')
+    await newsSection.scrollIntoViewIfNeeded()
+    await expect(newsSection).toBeVisible()
+
+    // The teaser features the newest articles from the shared data file.
+    for (const article of pressArticles.slice(0, 3)) {
+      await expect(newsSection.getByRole('heading', { name: article.headline })).toBeVisible()
+    }
+
+    const seeAll = newsSection.getByRole('link', { name: 'See All Press Coverage' })
+    await expect(seeAll).toBeVisible()
+    await seeAll.click()
+    await expect(page).toHaveURL(/\/in-the-news$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'In the News' })).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Description

Follow-up to #149: the new `/in-the-news` page was only reachable from the footer, with no presence in the main navigation (desktop or mobile), no home-page callout, and nothing acknowledging the 2026 parade that just happened. This PR weaves press coverage into the site's primary surfaces.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update
- [ ] CI/CD or tooling change

## Related Issue(s)

Refs #148

## Changes Made

- **Header navigation (desktop + mobile):** add a "News" item linking to `/in-the-news`. Page links now get pathname-based active state (via `usePathname`) alongside the existing scroll-spy for home-page anchors; the scroll-spy section list filters to anchor links only, and "Home" no longer shows active while on other pages.
- **Home page "In the News" section:** new `src/components/home-page/In-The-News/` section (id `news`) after Events, showing the three latest articles from `src/data/press-coverage.ts` as cards with a "See All Press Coverage" CTA — data-driven, so it updates automatically as coverage is added.
- **Post-parade banner:** `src/lib/parade.ts` now also reports `daysSincePrevious`/`previousYear`, and `ParadeCountdown` uses it for a two-week post-parade mode — instead of flipping to "364 days until the parade" the day after July 4, it thanks the community and links to the press coverage of the parade that just happened, then reverts to the countdown automatically.
- **Tests:** unit tests for the parade timing math (`__tests__/lib/parade.test.ts`) and the header News link; E2E tests for desktop-nav and mobile-hamburger navigation to `/in-the-news` and for the home-page teaser (headlines + CTA click-through).

## Screenshots (if applicable)

The new home section and nav item reuse the site's existing card, badge, and button patterns (matching the Events section and `/in-the-news` page styling).

## Testing Performed

### Manual Testing

- [x] Tested on desktop browsers (Chrome, Firefox, Safari, Edge) — verified via Playwright Chromium; components reuse existing responsive patterns
- [x] Tested on mobile devices/responsive views — mobile-menu and mobile-viewport E2E tests included
- [x] Verified all interactive elements work correctly
- [x] Checked console for errors

### Automated Testing

- [x] `npm run lint` - All linting checks pass (only pre-existing warnings in untouched files)
- [x] `npm test` - All unit tests pass (35/35, including 5 new)
- [x] `npm run build` - Build completes successfully
- [x] `npm run test:e2e` - All E2E tests pass (66 passed, 26 skipped, including 3 new)

### Accessibility

- [x] Keyboard navigation works correctly — standard links only; mobile menu unchanged
- [x] Color contrast meets WCAG standards — reuses the site's existing palette
- [x] Screen reader compatibility verified (if applicable) — semantic `article`/heading structure mirrors the Events section; countdown banner keeps its `aria-live` region

## Documentation

- [x] Code is self-documenting or includes comments where needed
- [ ] README.md updated (if needed) — N/A
- [ ] Other documentation updated (if needed) — N/A

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] My commits follow the conventional commit format
- [x] I have rebased my branch on the latest main

## Additional Notes

The post-parade banner window is a constant (`POST_PARADE_WINDOW_DAYS = 14`) in `ParadeCountdown.tsx` — easy to tune. After the window it reverts to the countdown with no further changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Xg1E1XP1cboF5NQugxQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6Xg1E1XP1cboF5NQugxQF)_