### PR TITLE
fix(smoke): navigate on 'load', not 'networkidle' (fixes false status-0 red)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -281,10 +281,15 @@ jobs:
             page.setDefaultTimeout(45000);
             let resp = null;
             try {
-              resp = await page.goto(url, { waitUntil: 'networkidle' });
+              // 'load' fires deterministically; 'networkidle' never fires on pages
+              // with persistent analytics/embed traffic (GTM, social widgets), which
+              // times out goto and zeroes the status even though the page is fine.
+              resp = await page.goto(url, { waitUntil: 'load' });
             } catch (e) {
               console.error('navigation error:', e.message);
             }
+            // Best-effort settle for late-loading assets before the screenshot.
+            await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
             const status = resp ? resp.status() : 0;
             const title = await page.title().catch(() => '');
             const bodyText = await page.evaluate(() => document.body && document.body.innerText || '').catch(() => '');


### PR DESCRIPTION
## What & why

Closes the root cause of #156. The daily smoke's visual check navigates with `waitUntil: 'networkidle'`, which **never fires on this site** — GTM/analytics and social embeds keep the network busy — so `page.goto` times out at 45s, the response stays `null`, and the run fails with `Visual: page status 0 (expected 200)` even though the site is fully up (curl 200, every compliance probe passes, complianceFailures `[]` — see run [29693783131](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/actions/runs/29693783131)).

## Fix

Same one-hunk change as template PR [FFC-IN-FFC_Single_Page_Template#411](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/pull/411):
- navigate with `waitUntil: 'load'` (deterministic)
- best-effort 10s `networkidle` settle before the screenshot

## Test plan

- Merge, then re-run Post-Deploy Smoke Test: expect green end-to-end and auto-close of #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)