### PR TITLE
fix(smoke): v3.1 — visual check waits for load, not networkidle

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -281,7 +281,11 @@ jobs:
             page.setDefaultTimeout(45000);
             let resp = null;
             try {
-              resp = await page.goto(url, { waitUntil: 'networkidle' });
+              // 'load', not 'networkidle': pages with live payment/analytics
+              // widgets (Stripe, Google Pay, Amplitude) beacon continuously and
+              // never reach network silence (found on freedomrisingusa.org).
+              resp = await page.goto(url, { waitUntil: 'load' });
+              await page.waitForTimeout(1500); // let client-side UI (cookie banner) mount
             } catch (e) {
               console.error('navigation error:', e.message);
             }


### PR DESCRIPTION
Sites with live payment/analytics widgets (Stripe/Google Pay/Amplitude on freedomrisingusa.org) beacon continuously and never reach networkidle, timing out the visual check on a healthy page. v3.1 waits for load + 1.5s settle. Refs FreeForCharity/FFC-Cloudflare-Automation#738.